### PR TITLE
Use always the id list in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ clearText(R.id.edittext)
 clickListItem(R.id.list, 4);
 clickListItemChild(R.id.list, 3, R.id.row_button);
 scrollListToPosition(R.id.list, 4);
-assertListItemCount(R.id.listId, 5)
-assertListNotEmpty(R.id.listId)
-assertDisplayedAtPosition(R.id.recycler, 0, "text");
-assertDisplayedAtPosition(R.id.listId, 0, R.id.text_field, "text");
-assertDisplayedAtPosition(R.id.recycler, 0, R.string.hello_world);
-assertDisplayedAtPosition(R.id.listId, 0, R.id.text_field, R.string.hello_world);
-assertCustomAssertionAtPosition(R.id.recycler, 0, customViewAssertion);
+assertListItemCount(R.id.list, 5)
+assertListNotEmpty(R.id.list)
+assertDisplayedAtPosition(R.id.list, 0, "text");
+assertDisplayedAtPosition(R.id.list, 0, R.id.text_field, "text");
+assertDisplayedAtPosition(R.id.list, 0, R.string.hello_world);
+assertDisplayedAtPosition(R.id.list, 0, R.id.text_field, R.string.hello_world);
+assertCustomAssertionAtPosition(R.id.list, 0, customViewAssertion);
 
 clickSpinnerItem(R.id.spinner, 1);
 ```


### PR DESCRIPTION
It's just a way to keep a style and ease glancing at the readme