### PR TITLE
Refactor permissiongranter

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,6 +10,12 @@ android {
     minSdkVersion minSdkVersionDeclared
     targetSdkVersion compileSdkVersionDeclared
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunnerArguments clearPackageData: 'true'
+  }
+
+  testOptions {
+    animationsDisabled true
+    execution 'ANDROIDX_TEST_ORCHESTRATOR'
   }
 
   lintOptions {
@@ -34,6 +40,11 @@ dependencies {
   testImplementation 'pl.pragmatists:JUnitParams:1.1.0'
   testImplementation 'org.assertj:assertj-core:1.7.0'
   testImplementation 'org.mockito:mockito-core:2.13.0'
+
+  androidTestImplementation 'androidx.test:core:1.1.0'
+  androidTestImplementation 'androidx.test:runner:1.1.1'
+  androidTestImplementation 'androidx.test:rules:1.1.1'
+
 }
 
 publish {

--- a/library/src/androidTest/AndroidManifest.xml
+++ b/library/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.schibsted.spain.barista">
+
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.READ_CONTACTS" />
+  <uses-permission android:name="android.permission.CAMERA" />
+  <uses-permission android:name="android.permission.CALL_PHONE" />
+
+  <application>
+    <activity
+        android:name=".internal.util.MockActivity"
+        android:theme="@style/Base.Theme.AppCompat" />
+  </application>
+</manifest>

--- a/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/MockActivity.kt
+++ b/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/MockActivity.kt
@@ -1,0 +1,6 @@
+package com.schibsted.spain.barista.internal.util
+
+import androidx.appcompat.app.AppCompatActivity
+
+class MockActivity: AppCompatActivity() {
+}

--- a/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/permissiongranter/PermissionGranterTest.kt
+++ b/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/permissiongranter/PermissionGranterTest.kt
@@ -1,0 +1,26 @@
+package com.schibsted.spain.barista.internal.util.permissiongranter
+
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import com.schibsted.spain.barista.interaction.PermissionGranter.allowPermissionsIfNeeded
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeFalse
+import org.junit.Rule
+import org.junit.Test
+
+class PermissionGranterTest: TestFixtures() {
+
+    @Test
+    fun grantOneNeededPermission() {
+        var granted = hasPermission(notGrantedA)
+        assumeFalse(granted)
+
+        activity.requestPermissions(arrayOf(notGrantedA), requestCode)
+        allowPermissionsIfNeeded(notGrantedA)
+
+        granted = hasPermission(notGrantedA)
+        assertTrue(granted)
+    }
+
+    private fun hasPermission(permission: String) =
+            activity.checkSelfPermission(permission) == PERMISSION_GRANTED
+}

--- a/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/permissiongranter/PermissionGranterTest.kt
+++ b/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/permissiongranter/PermissionGranterTest.kt
@@ -1,9 +1,12 @@
 package com.schibsted.spain.barista.internal.util.permissiongranter
 
 import android.content.pm.PackageManager.PERMISSION_GRANTED
+import androidx.test.uiautomator.UiObjectNotFoundException
 import com.schibsted.spain.barista.interaction.PermissionGranter.allowPermissionsIfNeeded
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeFalse
+import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -20,6 +23,29 @@ class PermissionGranterTest: TestFixtures() {
         granted = hasPermission(notGrantedA)
         assertTrue(granted)
     }
+
+    @Test
+    fun requestOneAlreadyGranted() {
+        var granted = hasPermission(grantedA)
+        assumeTrue(granted)
+
+        activity.requestPermissions(arrayOf(grantedA), requestCode)
+        allowPermissionsIfNeeded(grantedA)
+
+        granted = hasPermission(grantedA)
+        assertTrue(granted)
+    }
+
+    // Cannot request a permission not requested in the manifest
+    @Test(expected = UiObjectNotFoundException::class)
+    fun requestOneNotInManifest() {
+        val granted = hasPermission(notInManifest)
+        assumeFalse(granted)
+
+        activity.requestPermissions(arrayOf(notInManifest), requestCode)
+        allowPermissionsIfNeeded(notInManifest)
+    }
+
 
     private fun hasPermission(permission: String) =
             activity.checkSelfPermission(permission) == PERMISSION_GRANTED

--- a/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/permissiongranter/TestFixtures.kt
+++ b/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/permissiongranter/TestFixtures.kt
@@ -12,6 +12,7 @@ abstract class TestFixtures {
     protected val grantedB = CAMERA
     protected val notGrantedA = READ_CONTACTS
     protected val notGrantedB = CALL_PHONE
+    protected val notInManifest = ACCESS_WIFI_STATE
 
     protected val requestCode = 100
 
@@ -22,5 +23,5 @@ abstract class TestFixtures {
         get() = activityRule.activity
 
     @get:Rule
-    val grantPermissions = GrantPermissionRule.grant(grantedA, grantedB)
+    val grantPermissions: GrantPermissionRule = GrantPermissionRule.grant(grantedA, grantedB)
 }

--- a/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/permissiongranter/TestFixtures.kt
+++ b/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/permissiongranter/TestFixtures.kt
@@ -1,0 +1,26 @@
+package com.schibsted.spain.barista.internal.util.permissiongranter
+
+import android.Manifest.permission.*
+import androidx.test.rule.ActivityTestRule
+import androidx.test.rule.GrantPermissionRule
+import com.schibsted.spain.barista.internal.util.MockActivity
+import org.junit.Rule
+import org.junit.Test
+
+abstract class TestFixtures {
+    protected val grantedA = ACCESS_FINE_LOCATION
+    protected val grantedB = CAMERA
+    protected val notGrantedA = READ_CONTACTS
+    protected val notGrantedB = CALL_PHONE
+
+    protected val requestCode = 100
+
+    @get:Rule
+    val activityRule = ActivityTestRule<MockActivity>(MockActivity::class.java)
+
+    protected val activity: MockActivity
+        get() = activityRule.activity
+
+    @get:Rule
+    val grantPermissions = GrantPermissionRule.grant(grantedA, grantedB)
+}

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
@@ -19,13 +19,9 @@ private const val ALLOW_BUTTON_RESID = "permission_allow_button"
 object PermissionGranter {
   @JvmStatic
   fun allowPermissionsIfNeeded(permissionNeeded: String) {
-    try {
       if (dialogRequestNeededForPermission(permissionNeeded)) {
         clickGrantPermissionButton()
       }
-    } catch (e: UiObjectNotFoundException) {
-      Log.e("Barista", "There is no permissions dialog to interact with", e)
-    }
   }
 
   private fun dialogRequestNeededForPermission(permissionNeeded: String) =

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
@@ -14,11 +14,7 @@ import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
 
 private const val DIALOG_TIMEOUT = 3000L
-private val PERMISSIONS_DIALOG_ALLOW_ID = if (SDK_INT >= Q) {
-  "com.android.permissioncontroller:id/permission_allow_button"
-} else {
-  "com.android.packageinstaller:id/permission_allow_button"
-}
+private const val ALLOW_BUTTON_RESID = "permission_allow_button"
 
 object PermissionGranter {
   @JvmStatic
@@ -51,13 +47,15 @@ object PermissionGranter {
   }
 
   private fun UiDevice.findGrantPermissionButton() : UiObject =
-          findObject(dialogButtonSelector(PERMISSIONS_DIALOG_ALLOW_ID))
+          findObject(dialogButtonSelector(ALLOW_BUTTON_RESID))
 
-  private fun dialogButtonSelector(resId: String) : UiSelector =
-          UiSelector()
-            .clickable(true)
-            .checkable(false)
-            .resourceId(resId)
+  private fun dialogButtonSelector(resId: String) : UiSelector {
+      val regex = ".*$resId"
+      return UiSelector()
+              .clickable(true)
+              .checkable(false)
+              .resourceIdMatches(regex)
+  }
 
   private fun hasNeededPermission(context: Context, permissionNeeded: String): Boolean {
     val permissionStatus = checkSelfPermission(context, permissionNeeded)

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
@@ -9,7 +9,6 @@ import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
-import com.schibsted.spain.barista.interaction.BaristaSleepInteractions.sleepThread
 
 object PermissionGranter {
 
@@ -26,7 +25,7 @@ object PermissionGranter {
     try {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasNeededPermission(getApplicationContext(),
               permissionNeeded)) {
-        sleepThread(PERMISSIONS_DIALOG_DELAY.toLong())
+        Thread.sleep(PERMISSIONS_DIALOG_DELAY.toLong())
         val device = UiDevice.getInstance(getInstrumentation())
         val allowPermissions = device.findObject(UiSelector()
             .clickable(true)

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
@@ -1,51 +1,71 @@
 package com.schibsted.spain.barista.interaction
 
 import android.content.Context
-import android.content.pm.PackageManager
-import android.os.Build
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.M
+import android.os.Build.VERSION_CODES.Q
 import android.util.Log
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
 
+private const val DIALOG_TIMEOUT = 3000L
+private val PERMISSIONS_DIALOG_ALLOW_ID = if (SDK_INT >= Q) {
+  "com.android.permissioncontroller:id/permission_allow_button"
+} else {
+  "com.android.packageinstaller:id/permission_allow_button"
+}
+
 object PermissionGranter {
-
-  private val PERMISSIONS_DIALOG_DELAY = 3000
-  private val PERMISSIONS_DIALOG_ALLOW_ID = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-    "com.android.permissioncontroller:id/permission_allow_button"
-  } else {
-    "com.android.packageinstaller:id/permission_allow_button"
-  }
-  //    private static final String PERMISSIONS_DIALOG_DENY_ID = "com.android.packageinstaller:id/permission_deny_button";
-
   @JvmStatic
   fun allowPermissionsIfNeeded(permissionNeeded: String) {
     try {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasNeededPermission(getApplicationContext(),
-              permissionNeeded)) {
-        Thread.sleep(PERMISSIONS_DIALOG_DELAY.toLong())
-        val device = UiDevice.getInstance(getInstrumentation())
-        val allowPermissions = device.findObject(UiSelector()
-            .clickable(true)
-            .checkable(false)
-            .resourceId(PERMISSIONS_DIALOG_ALLOW_ID))
-        if (allowPermissions.exists()) {
-          allowPermissions.click()
-        }
+      if (dialogRequestNeededForPermission(permissionNeeded)) {
+        clickGrantPermissionButton()
       }
     } catch (e: UiObjectNotFoundException) {
       Log.e("Barista", "There is no permissions dialog to interact with", e)
     }
   }
 
+  private fun dialogRequestNeededForPermission(permissionNeeded: String) =
+          SDK_INT >= M && !hasNeededPermission(getApplicationContext(), permissionNeeded)
+
+  private fun clickGrantPermissionButton() {
+    val device = createDeviceInstance()
+    val grantPermissionButton = device.findGrantPermissionButton()
+    grantPermissionButton.safeClick()
+  }
+
+  private fun createDeviceInstance() : UiDevice =
+          UiDevice.getInstance(getInstrumentation())
+
+  private fun UiObject.safeClick() {
+    waitForExists(DIALOG_TIMEOUT)
+    click()
+    waitUntilGone(DIALOG_TIMEOUT)
+  }
+
+  private fun UiDevice.findGrantPermissionButton() : UiObject =
+          findObject(dialogButtonSelector(PERMISSIONS_DIALOG_ALLOW_ID))
+
+  private fun dialogButtonSelector(resId: String) : UiSelector =
+          UiSelector()
+            .clickable(true)
+            .checkable(false)
+            .resourceId(resId)
+
   private fun hasNeededPermission(context: Context, permissionNeeded: String): Boolean {
     val permissionStatus = checkSelfPermission(context, permissionNeeded)
-    return permissionStatus == PackageManager.PERMISSION_GRANTED
+    return permissionStatus == PERMISSION_GRANTED
   }
 
   private fun checkSelfPermission(context: Context, permission: String): Int {
     return context.checkPermission(permission, android.os.Process.myPid(), android.os.Process.myUid())
   }
+
 }

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
@@ -1,31 +1,25 @@
 package com.schibsted.spain.barista.interaction
 
-import android.content.Context
-import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.M
-import android.os.Build.VERSION_CODES.Q
-import android.util.Log
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject
-import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
 
-private const val DIALOG_TIMEOUT = 3000L
+private const val DIALOG_TIMEOUT = 1500L
 private const val ALLOW_BUTTON_RESID = "permission_allow_button"
 
 object PermissionGranter {
+  @Suppress("UNUSED_PARAMETER") // kept here for backward compatibility
   @JvmStatic
   fun allowPermissionsIfNeeded(permissionNeeded: String) {
-      if (dialogRequestNeededForPermission(permissionNeeded)) {
+      if (userInputNeededForPermission()) {
         clickGrantPermissionButton()
       }
   }
 
-  private fun dialogRequestNeededForPermission(permissionNeeded: String) =
-          SDK_INT >= M && !hasNeededPermission(getApplicationContext(), permissionNeeded)
+  private fun userInputNeededForPermission() = SDK_INT >= M
 
   private fun clickGrantPermissionButton() {
     val device = createDeviceInstance()
@@ -51,15 +45,6 @@ object PermissionGranter {
               .clickable(true)
               .checkable(false)
               .resourceIdMatches(regex)
-  }
-
-  private fun hasNeededPermission(context: Context, permissionNeeded: String): Boolean {
-    val permissionStatus = checkSelfPermission(context, permissionNeeded)
-    return permissionStatus == PERMISSION_GRANTED
-  }
-
-  private fun checkSelfPermission(context: Context, permission: String): Int {
-    return context.checkPermission(permission, android.os.Process.myPid(), android.os.Process.myUid())
   }
 
 }


### PR DESCRIPTION
I've refactored PermissionGranter to be more robust for testing.  

Summary: 
* Add instrumented tests that identify how Permissions work on Android.
* Increase legibility of code
* Increase robustness of UIAutomator code.  
  * Searching for button will timeout instead of pausing.
  * Will wait to make sure button is gone after clicking.
  * Use a regular expression to find Resource ID, which (presumably) will work if the package name changes in Android (again).

Some major issues I found when testing the Permission Granter:
1. It assumed that if a permission *has already been granted,* then it does not need to click the Grant Permission button.  It turns out this is false. Requesting a permission that has already been granted will still result in a permission dialog (tested on Android M, Pixel 3)
2. Assumed that if a permission has *not* been granted, then requesting it will show the permissions dialog.  This is false.  If a permission has not been added to the Manifest, requesting it does not show a dialog.

I've rewritten the code for the use case where the target-developer wants to test that their code correctly handles permissions. This required removing a lot to avoid false positives.  The result is more in line with a view action.

However, this has made the code no longer really fit the grantPermissionsIfNecessary() semantics.  Possibly instead of removing code, this function could also call activity.requestPermissions() so it full-on does everything for the user.  But I'm having a hard time thinking of a use-case where GrantPermissionRule would not work better.  (I also think this would not be backward compatible, since grantPermissionsIfNecessary() does not take an activity as a parameter).