### PR TITLE
Add scrollTo signatures to support scrolling on custom view matcher.

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaScrollInteractions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaScrollInteractions.kt
@@ -1,9 +1,9 @@
 package com.schibsted.spain.barista.interaction
 
+import android.view.View
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.PerformException
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import android.view.View
 import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
 import com.schibsted.spain.barista.internal.failurehandler.description
 import com.schibsted.spain.barista.internal.util.resourceMatcher
@@ -16,43 +16,53 @@ import org.hamcrest.Matcher
  */
 object BaristaScrollInteractions {
 
-  // This value has been mathematically calculated and proven to be precisely the exact number of retries needed to always work.
-  // Not really, we just tried hundreds of times with different values and this seems to be the best one.
-  private val MAX_SCROLL_ATTEMPTS = 50
+    // This value has been mathematically calculated and proven to be precisely the exact number of retries needed to always work.
+    // Not really, we just tried hundreds of times with different values and this seems to be the best one.
+    private val MAX_SCROLL_ATTEMPTS = 50
 
-  @JvmStatic
-  fun scrollTo(id: Int) {
-    scrollWithMultipleAttempts(id.resourceMatcher(), failAtEnd = true)
-  }
-
-  @JvmStatic
-  fun scrollTo(text: String) {
-    scrollWithMultipleAttempts(withText(text), failAtEnd = true)
-  }
-
-  @JvmStatic
-  fun safelyScrollTo(id: Int) {
-    scrollWithMultipleAttempts(id.resourceMatcher(), failAtEnd = false)
-  }
-
-  @JvmStatic
-  fun safelyScrollTo(text: String) {
-    scrollWithMultipleAttempts(withText(text), failAtEnd = false)
-  }
-
-  private fun scrollWithMultipleAttempts(matcher: Matcher<View>, failAtEnd: Boolean) {
-    val spyFailureHandler = SpyFailureHandler()
-    for (i in 1..MAX_SCROLL_ATTEMPTS) {
-      try {
-        onView(matcher)
-            .withFailureHandler(spyFailureHandler)
-            .perform(nestedScrollToAction())
-      } catch (exception: PerformException) {
-        if (i == MAX_SCROLL_ATTEMPTS && failAtEnd) {
-          spyFailureHandler
-              .resendLastError("Could not scroll to ${matcher.description()}. Retried ${MAX_SCROLL_ATTEMPTS} times but all failed")
-        }
-      }
+    @JvmStatic
+    fun scrollTo(matcher: Matcher<View>) {
+        scrollWithMultipleAttempts(matcher, failAtEnd = true)
     }
-  }
+
+    @JvmStatic
+    fun scrollTo(id: Int) {
+        scrollWithMultipleAttempts(id.resourceMatcher(), failAtEnd = true)
+    }
+
+    @JvmStatic
+    fun scrollTo(text: String) {
+        scrollWithMultipleAttempts(withText(text), failAtEnd = true)
+    }
+
+    @JvmStatic
+    fun safelyScrollTo(matcher: Matcher<View>) {
+        scrollWithMultipleAttempts(matcher, failAtEnd = false)
+    }
+
+    @JvmStatic
+    fun safelyScrollTo(id: Int) {
+        scrollWithMultipleAttempts(id.resourceMatcher(), failAtEnd = false)
+    }
+
+    @JvmStatic
+    fun safelyScrollTo(text: String) {
+        scrollWithMultipleAttempts(withText(text), failAtEnd = false)
+    }
+
+    private fun scrollWithMultipleAttempts(matcher: Matcher<View>, failAtEnd: Boolean) {
+        val spyFailureHandler = SpyFailureHandler()
+        for (i in 1..MAX_SCROLL_ATTEMPTS) {
+            try {
+                onView(matcher)
+                        .withFailureHandler(spyFailureHandler)
+                        .perform(nestedScrollToAction())
+            } catch (exception: PerformException) {
+                if (i == MAX_SCROLL_ATTEMPTS && failAtEnd) {
+                    spyFailureHandler
+                            .resendLastError("Could not scroll to ${matcher.description()}. Retried ${MAX_SCROLL_ATTEMPTS} times but all failed")
+                }
+            }
+        }
+    }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ScrollsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ScrollsTest.java
@@ -8,6 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertNotDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaScrollInteractions.safelyScrollTo;
@@ -21,6 +22,15 @@ public class ScrollsTest {
 
   @Rule
   public FailureHandlerValidatorRule handlerValidator = new FailureHandlerValidatorRule();
+
+  @Test
+  public void scrollsInsideScrollable_byCustomMatcher() {
+    assertTopVisible();
+
+    scrollTo(withId(R.id.really_far_away_button));
+
+    assertBottomVisible();
+  }
 
   @Test
   public void scrollsInsideScrollable_byId() {
@@ -54,6 +64,15 @@ public class ScrollsTest {
     assertTopVisible();
 
     scrollTo(R.id.centered_button);
+  }
+
+  @Test
+  public void safelyScrollsInsideScrollable_byCustomMatcher() throws Exception {
+    assertTopVisible();
+
+    safelyScrollTo(withId(R.id.really_far_away_button));
+
+    assertBottomVisible();
   }
 
   @Test


### PR DESCRIPTION
This is quite convenient when we have UI structure a bit more complex than a unique ID/string.