### PR TITLE
Feature: Add color styleable assertTextColorIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,20 @@ assertTextColorIsNot(R.id.some_red_text, R.color.blue);
 assertTextColorIsNot(R.id.some_color_list_text, R.color.another_state_list);
 ```
 
+`assertTextColorIs`and it `variant` assertTextColorIsNot` work with:
+
+- *Color int*: `Color.parse("#ff00ff")`
+- *Color resource*: `R.color.green`
+- *Color attribute*: `R.attr.colorPrimary`
+
+Also Barista can check colors parsed from `declarable-style` custom attribute:
+```java
+assertTextColorIs(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle, R.styleable.SampleCustomView_customColor);
+
+// ...or not?
+assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_Green, R.styleable.SampleCustomView_customColor);
+```
+
 #### Check recyclerView item count against expected item count
 ```java
 assertRecyclerViewItemCount(R.id.recycler, 10);

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -1,17 +1,20 @@
 package com.schibsted.spain.barista.assertion
 
-import androidx.annotation.ColorRes
+import android.view.View
+import androidx.annotation.AttrRes
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
+import androidx.annotation.StyleRes
+import androidx.annotation.StyleableRes
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import android.view.View
 import androidx.test.platform.app.InstrumentationRegistry
 import com.schibsted.spain.barista.internal.assertAny
 import com.schibsted.spain.barista.internal.matcher.TextColorMatcher
+import com.schibsted.spain.barista.internal.matcher.TextStyleableColorMatcher
 import com.schibsted.spain.barista.internal.util.resourceMatcher
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matcher
@@ -132,5 +135,31 @@ object BaristaVisibilityAssertions {
   @JvmStatic
   fun assertTextColorIsNot(@IdRes viewId: Int, color: Int) {
     viewId.resourceMatcher().assertAny(not(TextColorMatcher(color)))
+  }
+
+  @JvmStatic
+  fun assertTextColorIs(
+      @IdRes viewId: Int,
+      @StyleableRes styleableRes: IntArray,
+      @StyleRes styleRes: Int,
+      @AttrRes attrColor: Int
+  ) {
+    viewId.resourceMatcher().assertAny(TextStyleableColorMatcher(
+        styleableRes, styleRes, attrColor
+    ))
+  }
+
+  @JvmStatic
+  fun assertTextColorIsNot(
+      @IdRes viewId: Int,
+      @StyleableRes styleableRes: IntArray,
+      @StyleRes styleRes: Int,
+      @AttrRes attrColor: Int
+  ) {
+    viewId.resourceMatcher().assertAny(not(
+        TextStyleableColorMatcher(
+            styleableRes, styleRes, attrColor
+        )
+    ))
   }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaVisibilityAssertions.kt
@@ -142,7 +142,7 @@ object BaristaVisibilityAssertions {
       @IdRes viewId: Int,
       @StyleableRes styleableRes: IntArray,
       @StyleRes styleRes: Int,
-      @AttrRes attrColor: Int
+      @StyleableRes attrColor: Int
   ) {
     viewId.resourceMatcher().assertAny(TextStyleableColorMatcher(
         styleableRes, styleRes, attrColor
@@ -154,7 +154,7 @@ object BaristaVisibilityAssertions {
       @IdRes viewId: Int,
       @StyleableRes styleableRes: IntArray,
       @StyleRes styleRes: Int,
-      @AttrRes attrColor: Int
+      @StyleableRes attrColor: Int
   ) {
     viewId.resourceMatcher().assertAny(not(
         TextStyleableColorMatcher(

--- a/library/src/main/java/com/schibsted/spain/barista/internal/matcher/TextStyleableColorMatcher.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/matcher/TextStyleableColorMatcher.kt
@@ -6,17 +6,21 @@ import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
 import androidx.annotation.StyleableRes
 import androidx.test.espresso.matcher.BoundedMatcher
+import com.schibsted.spain.barista.internal.util.ColorResourceType
+import com.schibsted.spain.barista.internal.util.colorResourceType
 import org.hamcrest.Description
 
 class TextStyleableColorMatcher(
     @StyleableRes private val styleableRes: IntArray,
     @StyleRes private val styleRes: Int,
-    @AttrRes private val attrColor: Int
+    @StyleableRes private val attrColor: Int
 ) : BoundedMatcher<View, TextView>(TextView::class.java) {
 
-    private var colorName: String? = null
+    private var styleResName: String? = null
 
     override fun matchesSafely(textView: TextView): Boolean {
+        styleResName = textView.context.resources.getResourceEntryName(styleRes)
+
         return matchesColor(textView) || matchesColorList(textView)
     }
 
@@ -61,6 +65,6 @@ class TextStyleableColorMatcher(
     }
 
     override fun describeTo(description: Description) {
-        description.appendText("pending text")
+        description.appendText("with style matching [$styleResName]")
     }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/internal/matcher/TextStyleableColorMatcher.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/matcher/TextStyleableColorMatcher.kt
@@ -1,0 +1,66 @@
+package com.schibsted.spain.barista.internal.matcher
+import android.content.res.ColorStateList
+import android.view.View
+import android.widget.TextView
+import androidx.annotation.AttrRes
+import androidx.annotation.StyleRes
+import androidx.annotation.StyleableRes
+import androidx.test.espresso.matcher.BoundedMatcher
+import org.hamcrest.Description
+
+class TextStyleableColorMatcher(
+    @StyleableRes private val styleableRes: IntArray,
+    @StyleRes private val styleRes: Int,
+    @AttrRes private val attrColor: Int
+) : BoundedMatcher<View, TextView>(TextView::class.java) {
+
+    private var colorName: String? = null
+
+    override fun matchesSafely(textView: TextView): Boolean {
+        return matchesColor(textView) || matchesColorList(textView)
+    }
+
+    private fun matchesColor(textView: TextView): Boolean {
+        val currentColorInt = textView.currentTextColor
+        val expectedColorInt = getStyleableColor(textView)
+        return currentColorInt == expectedColorInt
+    }
+
+    private fun matchesColorList(textView: TextView): Boolean {
+        val currentColorList = textView.textColors
+        val expectedColorList = getStyleableColorList(textView)
+        return currentColorList == expectedColorList
+    }
+
+    private fun getStyleableColor(textView: TextView): Int {
+        val typedArray = textView.context.obtainStyledAttributes(
+                null,
+                styleableRes,
+                0,
+                styleRes
+        )
+
+        val expectedColorInt = typedArray.getColor(attrColor, -1)
+
+        typedArray.recycle()
+        return expectedColorInt
+    }
+
+    private fun getStyleableColorList(textView: TextView): ColorStateList? {
+        val typedArray = textView.context.obtainStyledAttributes(
+                null,
+                styleableRes,
+                0,
+                styleRes
+        )
+
+        val expectedColorInt = typedArray.getColorStateList(attrColor)
+
+        typedArray.recycle()
+        return expectedColorInt
+    }
+
+    override fun describeTo(description: Description) {
+        description.appendText("pending text")
+    }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   implementation 'androidx.annotation:annotation:1.0.2'
   implementation 'com.github.bumptech.glide:glide:4.7.1'
   implementation 'com.google.android.material:material:1.0.0'
+  implementation 'androidx.core:core-ktx:1.0.1'
 
   androidTestImplementation project(':library')
   androidTestImplementation "org.assertj:assertj-core:2.9.1"

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsSecondaryTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsSecondaryTest.java
@@ -1,0 +1,39 @@
+package com.schibsted.spain.barista.sample;
+
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
+import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
+import com.schibsted.spain.barista.sample.util.FailureHandlerValidatorRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertTextColorIs;
+import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertTextColorIsNot;
+
+@RunWith(AndroidJUnit4.class)
+public class ColorsSecondaryTest {
+
+  @Rule
+  public ActivityTestRule<ColorsSecondActivity> activityRule = new ActivityTestRule<>(ColorsSecondActivity.class);
+
+  @Rule
+  public FailureHandlerValidatorRule handlerValidator = new FailureHandlerValidatorRule();
+
+  @Test
+  public void checkColorStyleable_colorStateList() {
+    assertTextColorIs(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_ColorState, R.styleable.SampleCustomView_customColor);
+
+    assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_ColorState_Secondary, R.styleable.SampleCustomView_otherColor);
+  }
+
+  @Test(expected = BaristaException.class)
+  public void checkColorStyleable_colorStateList_fail() {
+    assertTextColorIs(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_ColorState_Secondary, R.styleable.SampleCustomView_customColor);
+  }
+
+  @Test(expected = BaristaException.class)
+  public void checkNotColorStyleable_colorStateList_fail() {
+    assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_ColorState, R.styleable.SampleCustomView_customColor);
+  }
+}

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsSecondaryTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsSecondaryTest.java
@@ -22,18 +22,38 @@ public class ColorsSecondaryTest {
 
   @Test
   public void checkColorStyleable_colorStateList() {
-    assertTextColorIs(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_ColorState, R.styleable.SampleCustomView_customColor);
+    assertTextColorIs(
+        R.id.customTextView,
+        R.styleable.SampleCustomView,
+        R.style.SampleCustomStyle_ColorState,
+        R.styleable.SampleCustomView_customColor
+    );
 
-    assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_ColorState_Secondary, R.styleable.SampleCustomView_otherColor);
+    assertTextColorIsNot(
+        R.id.customTextView,
+        R.styleable.SampleCustomView,
+        R.style.SampleCustomStyle_ColorState_Secondary,
+        R.styleable.SampleCustomView_otherColor
+    );
   }
 
   @Test(expected = BaristaException.class)
   public void checkColorStyleable_colorStateList_fail() {
-    assertTextColorIs(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_ColorState_Secondary, R.styleable.SampleCustomView_customColor);
+    assertTextColorIs(
+        R.id.customTextView,
+        R.styleable.SampleCustomView,
+        R.style.SampleCustomStyle_ColorState_Secondary,
+        R.styleable.SampleCustomView_customColor
+    );
   }
 
   @Test(expected = BaristaException.class)
   public void checkNotColorStyleable_colorStateList_fail() {
-    assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_ColorState, R.styleable.SampleCustomView_customColor);
+    assertTextColorIsNot(
+        R.id.customTextView,
+        R.styleable.SampleCustomView,
+        R.style.SampleCustomStyle_ColorState,
+        R.styleable.SampleCustomView_customColor
+    );
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsTest.java
@@ -41,15 +41,31 @@ public class ColorsTest {
   @Test
   public void checkColorInt() {
     assertTextColorIs(R.id.textColorInt, Color.parseColor("#ff0000"));
-    assertTextColorIsNot(R.id.textColorInt,  Color.parseColor("#ff00ff"));
+    assertTextColorIsNot(R.id.textColorInt, Color.parseColor("#ff00ff"));
   }
 
   @Test
   public void checkColorStyleable() {
-    assertTextColorIs(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle, R.styleable.SampleCustomView_customColor);
-    assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_Green, R.styleable.SampleCustomView_customColor);
+    assertTextColorIs(
+        R.id.customTextView,
+        R.styleable.SampleCustomView,
+        R.style.SampleCustomStyle,
+        R.styleable.SampleCustomView_customColor
+    );
 
-    assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle, R.styleable.SampleCustomView_otherColor);
+    assertTextColorIsNot(
+        R.id.customTextView,
+        R.styleable.SampleCustomView,
+        R.style.SampleCustomStyle_Green,
+        R.styleable.SampleCustomView_customColor
+    );
+
+    assertTextColorIsNot(
+        R.id.customTextView,
+        R.styleable.SampleCustomView,
+        R.style.SampleCustomStyle,
+        R.styleable.SampleCustomView_otherColor
+    );
   }
 
   @Test
@@ -111,11 +127,21 @@ public class ColorsTest {
 
   @Test(expected = BaristaException.class)
   public void checkColorStyleable_fail() {
-    assertTextColorIs(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_Green, R.styleable.SampleCustomView_customColor);
+    assertTextColorIs(
+        R.id.customTextView,
+        R.styleable.SampleCustomView,
+        R.style.SampleCustomStyle_Green,
+        R.styleable.SampleCustomView_customColor
+    );
   }
 
   @Test(expected = BaristaException.class)
   public void checkNotColorStyleable_fail() {
-    assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle, R.styleable.SampleCustomView_customColor);
+    assertTextColorIsNot(
+        R.id.customTextView,
+        R.styleable.SampleCustomView,
+        R.style.SampleCustomStyle,
+        R.styleable.SampleCustomView_customColor
+    );
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsTest.java
@@ -112,6 +112,10 @@ public class ColorsTest {
   @Test(expected = BaristaException.class)
   public void checkColorStyleable_fail() {
     assertTextColorIs(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_Green, R.styleable.SampleCustomView_customColor);
+  }
+
+  @Test(expected = BaristaException.class)
+  public void checkNotColorStyleable_fail() {
     assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle, R.styleable.SampleCustomView_customColor);
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ColorsTest.java
@@ -45,6 +45,14 @@ public class ColorsTest {
   }
 
   @Test
+  public void checkColorStyleable() {
+    assertTextColorIs(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle, R.styleable.SampleCustomView_customColor);
+    assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_Green, R.styleable.SampleCustomView_customColor);
+
+    assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle, R.styleable.SampleCustomView_otherColor);
+  }
+
+  @Test
   public void checkColorList_whenDisabled() {
     assertTextColorIs(R.id.textSelectorDisabled, R.color.selector_default_disabled_checked);
     assertTextColorIs(R.id.textSelectorDisabled, R.color.disabled);
@@ -99,5 +107,11 @@ public class ColorsTest {
   @Test(expected = BaristaException.class)
   public void checkColorList_whenChecked_fails() {
     assertTextColorIs(R.id.textSelectorChecked, R.color.disabled);
+  }
+
+  @Test(expected = BaristaException.class)
+  public void checkColorStyleable_fail() {
+    assertTextColorIs(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle_Green, R.styleable.SampleCustomView_customColor);
+    assertTextColorIsNot(R.id.customTextView, R.styleable.SampleCustomView, R.style.SampleCustomStyle, R.styleable.SampleCustomView_customColor);
   }
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -73,7 +73,8 @@
     <activity
         android:name=".ColorsActivity"
         android:exported="true"
-        />    <activity
+        />
+    <activity
         android:name=".ColorsSecondActivity"
         android:exported="true"
         />

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -73,6 +73,9 @@
     <activity
         android:name=".ColorsActivity"
         android:exported="true"
+        />    <activity
+        android:name=".ColorsSecondActivity"
+        android:exported="true"
         />
     <activity android:name=".KeyboardActivity"/>
     <activity android:name=".HintAndErrorActivity"/>

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/ColorsSecondActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/ColorsSecondActivity.java
@@ -1,0 +1,14 @@
+package com.schibsted.spain.barista.sample;
+
+import android.os.Bundle;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class ColorsSecondActivity extends AppCompatActivity {
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_color_second);
+  }
+}

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/widget/SampleCustomView.kt
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/widget/SampleCustomView.kt
@@ -32,6 +32,7 @@ constructor(
     LayoutInflater.from(context).inflate(R.layout.sample_custom_view, this, true)
     layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
 
+    customTextView.text = "Demo text"
     customTextView.setTextColor(customColor)
   }
 }

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/widget/SampleCustomView.kt
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/widget/SampleCustomView.kt
@@ -1,0 +1,37 @@
+package com.schibsted.spain.barista.sample.widget;
+
+import android.content.Context
+import android.graphics.Color
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.LinearLayout
+import androidx.core.content.withStyledAttributes
+import com.schibsted.spain.barista.sample.R
+import kotlinx.android.synthetic.main.sample_custom_view.view.customTextView
+
+class SampleCustomView @JvmOverloads
+constructor(
+    context: Context,
+    attributeSet: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.sampleCustomViewStyle,
+    defStyleRes: Int = R.style.SampleCustomStyle
+) : LinearLayout(context, attributeSet, defStyleAttr) {
+
+  private var customColor: Int = Color.GRAY
+
+  init {
+    context.withStyledAttributes(
+        attributeSet,
+        R.styleable.SampleCustomView,
+        defStyleAttr,
+        defStyleRes
+    ) {
+      customColor = getColor(R.styleable.SampleCustomView_customColor, customColor)
+    }
+
+    LayoutInflater.from(context).inflate(R.layout.sample_custom_view, this, true)
+    layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+
+    customTextView.setTextColor(customColor)
+  }
+}

--- a/sample/src/main/res/color/secondary_selector_default_disabled_checked.xml
+++ b/sample/src/main/res/color/secondary_selector_default_disabled_checked.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <item android:color="@color/disabled"
+        android:state_checked="true"/>
+  <item android:color="@color/checked"
+        android:state_enabled="false"/>
+  <item android:color="#ff0000"/>
+
+</selector>

--- a/sample/src/main/res/layout/activity_color.xml
+++ b/sample/src/main/res/layout/activity_color.xml
@@ -62,4 +62,10 @@
       android:textColor="@color/selector_default_disabled_checked"
       />
 
+  <com.schibsted.spain.barista.sample.widget.SampleCustomView
+      android:id="@+id/sampleView"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      />
+
 </LinearLayout>

--- a/sample/src/main/res/layout/activity_color_second.xml
+++ b/sample/src/main/res/layout/activity_color_second.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    >
+
+  <com.schibsted.spain.barista.sample.widget.SampleCustomView
+      android:id="@+id/sampleView"
+      style="@style/SampleCustomStyle.ColorState"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      />
+
+</LinearLayout>

--- a/sample/src/main/res/layout/sample_custom_view.xml
+++ b/sample/src/main/res/layout/sample_custom_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:parentTag="android.widget.LinearLayout"
+    >
+
+  <TextView
+      android:id="@+id/customTextView"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      />
+
+</merge>

--- a/sample/src/main/res/values/attrs.xml
+++ b/sample/src/main/res/values/attrs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <declare-styleable name="SampleCustomView">
+    <attr name="customColor" format="color"/>
+    <attr name="otherColor" format="color"/>
+  </declare-styleable>
+
+  <attr name="sampleCustomViewStyle" format="reference" />
+
+</resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -27,4 +27,12 @@
     <item name="otherColor">#FF0000</item>
   </style>
 
+  <style name="SampleCustomStyle.ColorState">
+    <item name="customColor">@color/selector_default_disabled_checked</item>
+  </style>
+
+  <style name="SampleCustomStyle.ColorState.Secondary">
+    <item name="customColor">@color/secondary_selector_default_disabled_checked</item>
+  </style>
+
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -7,6 +7,7 @@
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccent</item>
+    <item name="sampleCustomViewStyle">@style/SampleCustomStyle</item>
   </style>
 
   <style name="MaterialAppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar"/>
@@ -14,6 +15,16 @@
   <style name="AppTheme.NoActionBar">
     <item name="windowActionBar">false</item>
     <item name="windowNoTitle">true</item>
+  </style>
+
+  <style name="SampleCustomStyle">
+    <item name="customColor">#FF0000</item>
+    <item name="otherColor">#00FF00</item>
+  </style>
+
+  <style name="SampleCustomStyle.Green">
+    <item name="customColor">#00FF00</item>
+    <item name="otherColor">#FF0000</item>
   </style>
 
 </resources>


### PR DESCRIPTION
Add ability to get color for `assertTextColorIs` from styleable and style resource:

``` kotlin
assertTextColorIs(
   R.id.customTextView,
   R.styleable.SampleCustomView,
   R.style.SampleCustomStyle,
   R.styleable.SampleCustomView_customColor
);
```

This way, if text color is not matching the color defined in the property `customColor`of `SampleCustomStyle` it will fail