### PR TITLE
Exclude Room metadata when clearing DB

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/rule/cleardata/ClearDatabaseRule.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/cleardata/ClearDatabaseRule.kt
@@ -24,11 +24,6 @@ class ClearDatabaseRule(private val databaseOperations: DatabaseOperations = Dat
     return this
   }
 
-  fun excludeRoomMetadataTable(): ClearDatabaseRule {
-    excludeTablesRegex = Regex(ROOM_METADATA)
-    return this
-  }
-
   override fun apply(base: Statement, description: Description): Statement {
     return object : Statement() {
       override fun evaluate() {
@@ -48,6 +43,7 @@ class ClearDatabaseRule(private val databaseOperations: DatabaseOperations = Dat
                 .use { database ->
                   getTableNames(database)
                       .filterNot { excludeTablesRegex?.matches(it) ?: false }
+                      .filterNot { it == ROOM_METADATA }
                       .forEach { tableName ->
                         deleteTableContent(database, tableName)
                       }

--- a/library/src/main/java/com/schibsted/spain/barista/rule/cleardata/ClearDatabaseRule.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/cleardata/ClearDatabaseRule.kt
@@ -14,12 +14,18 @@ class ClearDatabaseRule(private val databaseOperations: DatabaseOperations = Dat
   companion object {
     @JvmField
     internal val UNWANTED_FILENAME_SUFFIXES = arrayOf("-journal", "-shm", "-uid", "-wal")
+    const val ROOM_METADATA = "room_master_table"
   }
 
   private var excludeTablesRegex: Regex? = null
 
   fun excludeTablesMatching(tableNameRegexFilter: String): ClearDatabaseRule {
     excludeTablesRegex = Regex(tableNameRegexFilter)
+    return this
+  }
+
+  fun excludeRoomMetadataTable(): ClearDatabaseRule {
+    excludeTablesRegex = Regex(ROOM_METADATA)
     return this
   }
 

--- a/library/src/main/java/com/schibsted/spain/barista/rule/cleardata/internal/DatabaseOperations.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/cleardata/internal/DatabaseOperations.kt
@@ -1,14 +1,14 @@
 package com.schibsted.spain.barista.rule.cleardata.internal
 
 import android.database.sqlite.SQLiteDatabase
-import androidx.test.InstrumentationRegistry
+import androidx.test.platform.app.InstrumentationRegistry
 import java.io.File
 import java.util.ArrayList
 
 class DatabaseOperations {
 
   fun getAllDatabaseFiles(): List<File> {
-    return InstrumentationRegistry.getTargetContext()
+    return InstrumentationRegistry.getInstrumentation().targetContext
         .let { context ->
           context.databaseList()
               .map { context.getDatabasePath(it) }

--- a/library/src/test/java/com/schibsted/spain/barista/cleardata/ClearDatabaseRuleTest.java
+++ b/library/src/test/java/com/schibsted/spain/barista/cleardata/ClearDatabaseRuleTest.java
@@ -123,8 +123,7 @@ public class ClearDatabaseRuleTest {
     given(operations.getAllDatabaseFiles()).willReturn(singletonList(DB_1_FILE));
     given(operations.getTableNames(DB_1)).willReturn(asList(givenTableName, ClearDatabaseRule.ROOM_METADATA));
 
-    ClearDatabaseRule rule = new ClearDatabaseRule(operations)
-            .excludeRoomMetadataTable();
+    ClearDatabaseRule rule = new ClearDatabaseRule(operations);
     executeRule(rule);
 
     verify(operations, never()).deleteTableContent(DB_1, ClearDatabaseRule.ROOM_METADATA);

--- a/library/src/test/java/com/schibsted/spain/barista/cleardata/ClearDatabaseRuleTest.java
+++ b/library/src/test/java/com/schibsted/spain/barista/cleardata/ClearDatabaseRuleTest.java
@@ -117,6 +117,20 @@ public class ClearDatabaseRuleTest {
     verify(operations, atLeastOnce()).deleteTableContent(DB_1, "some_table");
   }
 
+  @Test
+  public void doesNotDeleteRoomMetadata() throws Throwable {
+    String givenTableName = "some_table";
+    given(operations.getAllDatabaseFiles()).willReturn(singletonList(DB_1_FILE));
+    given(operations.getTableNames(DB_1)).willReturn(asList(givenTableName, ClearDatabaseRule.ROOM_METADATA));
+
+    ClearDatabaseRule rule = new ClearDatabaseRule(operations)
+            .excludeRoomMetadataTable();
+    executeRule(rule);
+
+    verify(operations, never()).deleteTableContent(DB_1, ClearDatabaseRule.ROOM_METADATA);
+    verify(operations, atLeastOnce()).deleteTableContent(DB_1, givenTableName);
+  }
+
   private void executeRule(ClearDatabaseRule rule) throws Throwable {
     rule.apply(dummyStatement, dummyDescription).evaluate();
   }


### PR DESCRIPTION
- Provide Room metadata table name and method to exclude it from DB clearing process
- Implement test case: `doesNotDeleteRoomMetadata`
- Replace deprecated method: `InstrumentationRegistry.getTargetContext()`

Room has become the most popular ORM library and it is officially supported by Google Android team. This library creates and populates automatically a table with important database metadata: identity hash of our implemented database schema. If this metadata is deleted it can cause unexpected behavior or even crashes (`IllegalStateException`).
For more info see:
[Understanding migrations with Room](https://medium.com/androiddevelopers/understanding-migrations-with-room-f01e04b07929)
[How does Room verify data integrity](https://stackoverflow.com/questions/57547129/how-does-room-verify-data-integrity-where-are-the-db-versions-hashes-stored)
Few people is aware of this, so it is good to provide built in logic to allow easy understand and usage of this rule when using Room