### PR TITLE
Change .kotlin_module generated name

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,6 +15,7 @@ android {
   lintOptions {
     disable 'InvalidPackage'
   }
+  kotlinOptions.freeCompilerArgs += ["-module-name", "barista"]
 }
 
 dependencies {


### PR DESCRIPTION
Hi, I confronted the following error while building with barista and an internal company's library.

> Duplicate files copied in APK META-INF/library_release.kotlin_module

And found out that barista is taking this name too:
![image](https://user-images.githubusercontent.com/2308331/82398334-efd60d80-9a52-11ea-8ee7-72aca0c0c843.png)

I've already fixed on our side but think this could be useful for other barista users.

------

This PR has as purpose avoid taking the name of the current folder to generate the
kotlin_module generated into the .aar/META-INF.

In practice, rename "META-INF/library_release.kotlin_module" to
"META-INF/barista.kotlin_module".

This avoid Barista consumers to exclude this file if another library
generated the same one.

See: https://stackoverflow.com/q/4450960