### PR TITLE
Add Sponsor button linking to our "Thank you" post

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: "https://github.com/AdevintaSpain/Barista/issues/344"


### PR DESCRIPTION
I just learned we can use custom links for the Sponsor button in GitHub!

So we can link to our "Thank you Barista " issue. We don't want money, just "thank you" notes :) 

Here's more info about the button: https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository