### PR TITLE
Remove Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -36,7 +36,7 @@ dependencies {
   testImplementation 'junit:junit:4.12'
   testImplementation 'pl.pragmatists:JUnitParams:1.1.0'
   testImplementation 'org.assertj:assertj-core:1.7.0'
-  testImplementation 'org.mockito:mockito-core:2.13.0'
+  testImplementation 'org.mockito:mockito-core:2.28.2'
 }
 
 publish {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   implementation 'androidx.recyclerview:recyclerview:1.0.0'
   implementation 'com.google.android.material:material:1.0.0'
   implementation 'androidx.annotation:annotation:1.0.2'
-  implementation 'com.github.bumptech.glide:glide:4.7.1'
+  implementation 'com.github.bumptech.glide:glide:4.10.0'
   implementation 'com.google.android.material:material:1.0.0'
   implementation 'androidx.core:core-ktx:1.0.1'
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   androidTestImplementation project(':library')
   androidTestImplementation "org.assertj:assertj-core:2.9.1"
   androidTestImplementation "com.nhaarman:mockito-kotlin:1.5.0"
-  androidTestImplementation "org.mockito:mockito-android:2.16.0"
+  androidTestImplementation "org.mockito:mockito-android:2.28.2"
 
   testImplementation 'junit:junit:4.12'
 


### PR DESCRIPTION
This library doesn't depend on any android support library (except glide, that it's just used in the sample app and I updated it). So we can remove jetifier safely and get faster builds 🎉.

I needed to update `mockito-android` because when I removed jetifier mockito start complaining about "final interfaces". The ways of ~the lord~ mockito are inscrutable.

BTW: there are two tests failing at `master` right now and they fail in this PR too: `checkColorList_whenDisabled` and `checkColorList_whenChecked`.