### PR TITLE
Make FlakyRule tests less flaky

### DIFF
--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/FlakyTestRuleTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/FlakyTestRuleTest.java
@@ -9,11 +9,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withId;
-
 public class FlakyTestRuleTest {
 
   private static boolean hasRunAllowFlakyTest = false;
@@ -34,8 +29,6 @@ public class FlakyTestRuleTest {
   public void repeatAnnotationTest() throws Exception {
     activityRule.launchActivity(null);
 
-    onView(withId(R.id.some_view)).check(matches(isDisplayed()));
-
     if (hasRunRepeatTest) {
       throw new TestException("Test failure on second try");
     } else {
@@ -48,8 +41,6 @@ public class FlakyTestRuleTest {
   public void allowFlakyAnnotationTest() throws Exception {
     activityRule.launchActivity(null);
 
-    onView(withId(R.id.some_view)).check(matches(isDisplayed()));
-
     if (!hasRunAllowFlakyTest) {
       hasRunAllowFlakyTest = true;
       throw new TestException("Test failure on first try");
@@ -59,8 +50,6 @@ public class FlakyTestRuleTest {
   @Test
   public void testWithoutAnnotations() throws Exception {
     activityRule.launchActivity(null);
-
-    onView(withId(R.id.some_view)).check(matches(isDisplayed()));
   }
 
   private static class TestException extends Exception {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/FlakyTestRuleTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/FlakyTestRuleTest.java
@@ -4,7 +4,6 @@ import androidx.test.rule.ActivityTestRule;
 import com.schibsted.spain.barista.rule.flaky.AllowFlaky;
 import com.schibsted.spain.barista.rule.flaky.FlakyTestRule;
 import com.schibsted.spain.barista.rule.flaky.Repeat;
-import java.util.Random;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,7 +16,8 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 public class FlakyTestRuleTest {
 
-  private final Random random = new Random();
+  private static boolean hasRunAllowFlakyTest = false;
+  private static boolean hasRunRepeatTest = false;
 
   private ActivityTestRule<HelloWorldActivity> activityRule = new ActivityTestRule<>(HelloWorldActivity.class, true, false);
   private FlakyTestRule flakyRule = new FlakyTestRule()
@@ -29,32 +29,35 @@ public class FlakyTestRuleTest {
 
   // WARNING: this test must fail when run
   @Test
-  @Repeat(times = 5)
+  @Repeat(times = 2)
   @Ignore
-  public void someImportantFlakyTest() throws Exception {
+  public void repeatAnnotationTest() throws Exception {
     activityRule.launchActivity(null);
 
     onView(withId(R.id.some_view)).check(matches(isDisplayed()));
 
-    if (random.nextFloat() > 0.3) {
-      throw new TestException("Random test failure");
+    if (hasRunRepeatTest) {
+      throw new TestException("Test failure on second try");
+    } else {
+      hasRunRepeatTest = true;
     }
   }
 
   @Test
-  @AllowFlaky(attempts = 10)
-  public void someFlakyTest() throws Exception {
+  @AllowFlaky(attempts = 2)
+  public void allowFlakyAnnotationTest() throws Exception {
     activityRule.launchActivity(null);
 
     onView(withId(R.id.some_view)).check(matches(isDisplayed()));
 
-    if (random.nextFloat() > 0.3) {
-      throw new TestException("Random test failure");
+    if (!hasRunAllowFlakyTest) {
+      hasRunAllowFlakyTest = true;
+      throw new TestException("Test failure on first try");
     }
   }
 
   @Test
-  public void someDeterministicTest() throws Exception {
+  public void testWithoutAnnotations() throws Exception {
     activityRule.launchActivity(null);
 
     onView(withId(R.id.some_view)).check(matches(isDisplayed()));


### PR DESCRIPTION
Using a random is not an ideal way to test the flaky rule. Because, once in a while, the randomness will make the test fail. 

I replaced the random condition with a static boolean, that is shared between test repetitions. That way it's easier to deterministically make the test fail the first time only.

This should avoid some test failures that I've seen on CI