### PR TITLE
Downgrade emulator version for better stability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: reactivecircus/android-emulator-runner@v2.11.0
       name: Run tests
       with:
-        api-level: 29
+        api-level: 28
         profile: Nexus 6
         headless: true
         disable-animations: true


### PR DESCRIPTION
I've seen some really weird test failures in our project when using API 29.

I'm not sure that they are also happening here, but since tests are failing so much in the _experimental_ CI with Github Actions, it's worth trying a downgrade to API 28.