### PR TITLE
Feature: Update PermissionGranter to allow android 11 permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,19 @@ env:
   global:
   - secure: "pus/Wv/014aNnUbUDNBpAk12o3w/zEO+/0oPomdnFs5034tsUOk53VbV69qKdWGKtH8Gm9LGBL50GLjSiB9Cxnc66BCPGj1ykBQ8RGGG/KHTDg22fuRVXmrSbEc+SqjwhpyUTpFjTf9RDmR2qlh427RbGofaNmkv7ePX14OHDjfVJW39jVNJv6+Jluyuh98zGpEbKq1SW+kNJsXUJMQjBtgyaQWN0qIjWflZWv4Rn97vxhyxFtRdGtJl1qCyhAcoIXNJyiYuabn/7sGsv4BjjmVBpFOU9npeJ/uMoXv8HQitjmV5wF9vq3VjmdPua9mrJwqG8BvREEA6r/Hj6vPpm0+qM62bDxpINZX3c9CjrvauaMeNSx3rfxK2yYfYO+f7cVaf0hsYS/pc9Pk0LeJy2FhycBt+WNlj/HSFu5Cvmh38kAj6Dm4HveF/CGFuhXYJAGr8IVH7aCPUeEC6JJLEoylNLglasitvNnfi/5f/smJWGf6e/XhFpAjlhoztRv6Hq7yRX3KZWWYmdl5blrsf6OWv7Z3R60IXfe4caPGMuBZNHToUyRmDfk89GXIJWTmVL4NLYSfO7fSaZ0YJ7nkDhoAgW/oRJuqEdbD404Sfzjp/o9YI6GoU9nxWD/RGRY/PGZ1pQs9djI6wny93kV/Y5W1h9BslEiKf1cxzj337M5s="
   - secure: "pqbCHzhC2ePQt22kFqwA5RqQiJiQmlT8BEv5cPn84FVtGX0x1Qaw6NQ9k5ap2h/KGD0Axif5AdpruYRp4bicpscYOMLpk4fznXkNAX6U6MaQXR0ITgC2JTDtAZnAYuXo377uvdtHT0zPPfv/9mv5qY1bKdaCcRCSL8GX60ywf1YspJZNo7gC9yDZ6TiGTFTKycQqx1lPuPvtTopbp9oP6gDTnGhHDCrnn4Xi1NyyFnKJYVqaHSR25WgWAevNLnOA1Rbc7T67mrzzfeVv6wgS5+lJOuLCY1OgUwGrNmfqKVL67vUWYm5KuGFuHrV5pSiL6Y0CzJuI5gQl4H2h5tpadaEqOV5PswaWbqRW3aQGMsOKsLwv0oJIBcjE0NjkMx4Jusa7f1ofBkXWN2S8ozPDF8oVpJohzl8p2Fnhdrj+2f0eR+MBWFagWFwFeEKFGB1HDqF+XDQW21/Mar6nKc4tj2/wEtBcwfXL0Jo4c6O1GrUanyXLh4fXxIyuetoYIqwkG6hAvshXyoe0RP6UdifWiWnyEKu5Db6JV8IzjuR1QHCbcXjtXpl7Z6JodkRMw5bQzW9rrXTybRqK+ha+p3e/d1iynhjerxzavMadqSamWv02wQYD+vmeuf58SwZcy6XJJtJZ4M6yVL8msiVpsxpX/ln1jWHFEUKwJRRxKBkTHZo="
+
+before_install:
+  - yes | sdkmanager "platforms;android-30"
+
 android:
   components:
   - tools
   - tools
   - platform-tools
   - build-tools-28.0.3
-  - android-29
+  - android-30
   - extra
-  - addon
+  - add-on
 
   licenses:
   - 'android-sdk-license-.+'

--- a/README.md
+++ b/README.md
@@ -383,6 +383,9 @@ The new Marshmallow permissions system requires checking for permissions at runt
 ```java
 PermissionGranter.allowPermissionsIfNeeded(Manifest.permission.GET_ACCOUNTS);
 ```
+```java
+PermissionGranter.allowPermissionOneTime(Manifest.permission.GET_ACCOUNTS);
+```
 
 ## Useful test rules
 Barista includes a set of useful test rules to help you:

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ task clean(type: Delete) {
 }
 
 ext.minSdkVersionDeclared = 19
-ext.compileSdkVersionDeclared = 29
+ext.compileSdkVersionDeclared = 30
 
 ext.supportLibVersion = '27.1.1'
 ext.espressoVersion = '3.0.2'

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
@@ -1,7 +1,5 @@
 package com.schibsted.spain.barista.interaction
 
-import android.Manifest.permission.ACCESS_COARSE_LOCATION
-import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
@@ -16,17 +14,12 @@ import com.schibsted.spain.barista.interaction.BaristaSleepInteractions.sleepThr
 object PermissionGranter {
 
   private val PERMISSIONS_DIALOG_DELAY = 3000
-  private val PERMISSIONS_DIALOG_ALLOW_ID = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-    "com.android.permissioncontroller:id/permission_allow_button"
-  } else {
+
+  private val PERMISSION_DIALOG_ALLOW_IDS = listOf(
+    "com.android.permissioncontroller:id/permission_allow_foreground_only_button",
+    "com.android.permissioncontroller:id/permission_allow_button",
     "com.android.packageinstaller:id/permission_allow_button"
-  }
-  private val PERMISSIONS_DIALOG_ALLOW_FOREGROUND_ID = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-    "com.android.permissioncontroller:id/permission_allow_foreground_only_button"
-  } else {
-      PERMISSIONS_DIALOG_ALLOW_ID
-  }
-  //    private static final String PERMISSIONS_DIALOG_DENY_ID = "com.android.packageinstaller:id/permission_deny_button";
+  )
 
   @JvmStatic
   fun allowPermissionsIfNeeded(permissionNeeded: String) {
@@ -36,15 +29,16 @@ object PermissionGranter {
         sleepThread(PERMISSIONS_DIALOG_DELAY.toLong())
         val device = UiDevice.getInstance(getInstrumentation())
 
-        val resourceId = if (permissionNeeded == ACCESS_FINE_LOCATION || permissionNeeded == ACCESS_COARSE_LOCATION) {
-            PERMISSIONS_DIALOG_ALLOW_FOREGROUND_ID
-        } else {
-            PERMISSIONS_DIALOG_ALLOW_ID
-        }
+        val regex = PERMISSION_DIALOG_ALLOW_IDS.joinToString(
+          prefix = "^(",
+          separator = "|",
+          postfix = ")$"
+        ) { it }
         val allowPermissions = device.findObject(UiSelector()
             .clickable(true)
             .checkable(false)
-            .resourceId(resourceId))
+            .resourceIdMatches(regex)
+        )
         if (allowPermissions.exists()) {
           allowPermissions.click()
         }

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
@@ -15,8 +15,14 @@ object PermissionGranter {
 
   private val PERMISSIONS_DIALOG_DELAY = 3000
 
-  private val PERMISSION_DIALOG_ALLOW_IDS = listOf(
+  private val PERMISSION_DIALOG_ALLOW_FOREGROUND_IDS = listOf(
     "com.android.permissioncontroller:id/permission_allow_foreground_only_button",
+    "com.android.permissioncontroller:id/permission_allow_button",
+    "com.android.packageinstaller:id/permission_allow_button"
+  )
+
+  private val PERMISSION_DIALOG_ALLOW_ONE_TIME_IDS = listOf(
+    "com.android.permissioncontroller:id/permission_allow_one_time_button",
     "com.android.permissioncontroller:id/permission_allow_button",
     "com.android.packageinstaller:id/permission_allow_button"
   )
@@ -29,7 +35,34 @@ object PermissionGranter {
         sleepThread(PERMISSIONS_DIALOG_DELAY.toLong())
         val device = UiDevice.getInstance(getInstrumentation())
 
-        val regex = PERMISSION_DIALOG_ALLOW_IDS.joinToString(
+        val regex = PERMISSION_DIALOG_ALLOW_FOREGROUND_IDS.joinToString(
+          prefix = "^(",
+          separator = "|",
+          postfix = ")$"
+        ) { it }
+        val allowPermissions = device.findObject(UiSelector()
+            .clickable(true)
+            .checkable(false)
+            .resourceIdMatches(regex)
+        )
+        if (allowPermissions.exists()) {
+          allowPermissions.click()
+        }
+      }
+    } catch (e: UiObjectNotFoundException) {
+      Log.e("Barista", "There is no permissions dialog to interact with", e)
+    }
+  }
+
+  @JvmStatic
+  fun allowPermissionOneTime(permissionNeeded: String) {
+    try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasNeededPermission(getApplicationContext(),
+              permissionNeeded)) {
+        sleepThread(PERMISSIONS_DIALOG_DELAY.toLong())
+        val device = UiDevice.getInstance(getInstrumentation())
+
+        val regex = PERMISSION_DIALOG_ALLOW_ONE_TIME_IDS.joinToString(
           prefix = "^(",
           separator = "|",
           postfix = ")$"

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
@@ -35,15 +35,15 @@ object PermissionGranter {
 
   @JvmStatic
   fun allowPermissionsIfNeeded(permissionNeeded: String) {
-    allowPermission(permissionNeeded, PERMISSION_DIALOG_ALLOW_FOREGROUND_IDS)
+    allowPermission(permissionNeeded, PERMISSION_DIALOG_ALLOW_FOREGROUND_IDS.toPermissionButtonRegex())
   }
 
   @JvmStatic
   fun allowPermissionOneTime(permissionNeeded: String) {
-    allowPermission(permissionNeeded, PERMISSION_DIALOG_ALLOW_ONE_TIME_IDS)
+    allowPermission(permissionNeeded, PERMISSION_DIALOG_ALLOW_ONE_TIME_IDS.toPermissionButtonRegex())
   }
 
-  private fun allowPermission(permissionNeeded: String, permissionsIds: List<String>) {
+  private fun allowPermission(permissionNeeded: String, permissionsIds: String) {
     try {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasNeededPermission(
           getApplicationContext(),
@@ -52,13 +52,11 @@ object PermissionGranter {
         sleepThread(PERMISSIONS_DIALOG_DELAY.toLong())
         val device = UiDevice.getInstance(getInstrumentation())
 
-        val regex = this.PERMISSION_DIALOG_ALLOW_ONE_TIME_IDS.toPermissionButtonRegex()
-
         val allowPermissions = device.findObject(
           UiSelector()
             .clickable(true)
             .checkable(false)
-            .resourceIdMatches(regex)
+            .resourceIdMatches(permissionsIds)
         )
         if (allowPermissions.exists()) {
           allowPermissions.click()

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
@@ -10,7 +10,6 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
 import com.schibsted.spain.barista.interaction.BaristaSleepInteractions.sleepThread
-import com.schibsted.spain.barista.interaction.PermissionGranter.toPermissionButtonRegex
 
 object PermissionGranter {
 
@@ -36,39 +35,27 @@ object PermissionGranter {
 
   @JvmStatic
   fun allowPermissionsIfNeeded(permissionNeeded: String) {
-    try {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasNeededPermission(getApplicationContext(),
-              permissionNeeded)) {
-        sleepThread(PERMISSIONS_DIALOG_DELAY.toLong())
-        val device = UiDevice.getInstance(getInstrumentation())
-
-        val regex = PERMISSION_DIALOG_ALLOW_FOREGROUND_IDS.toPermissionButtonRegex()
-
-        val allowPermissions = device.findObject(UiSelector()
-            .clickable(true)
-            .checkable(false)
-            .resourceIdMatches(regex)
-        )
-        if (allowPermissions.exists()) {
-          allowPermissions.click()
-        }
-      }
-    } catch (e: UiObjectNotFoundException) {
-      Log.e("Barista", "There is no permissions dialog to interact with", e)
-    }
+    allowPermission(permissionNeeded, PERMISSION_DIALOG_ALLOW_FOREGROUND_IDS)
   }
 
   @JvmStatic
   fun allowPermissionOneTime(permissionNeeded: String) {
+    allowPermission(permissionNeeded, PERMISSION_DIALOG_ALLOW_ONE_TIME_IDS)
+  }
+
+  private fun allowPermission(permissionNeeded: String, permissionsIds: List<String>) {
     try {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasNeededPermission(getApplicationContext(),
-              permissionNeeded)) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasNeededPermission(
+          getApplicationContext(),
+          permissionNeeded
+        )) {
         sleepThread(PERMISSIONS_DIALOG_DELAY.toLong())
         val device = UiDevice.getInstance(getInstrumentation())
 
-        val regex = PERMISSION_DIALOG_ALLOW_ONE_TIME_IDS.toPermissionButtonRegex()
+        val regex = this.PERMISSION_DIALOG_ALLOW_ONE_TIME_IDS.toPermissionButtonRegex()
 
-        val allowPermissions = device.findObject(UiSelector()
+        val allowPermissions = device.findObject(
+          UiSelector()
             .clickable(true)
             .checkable(false)
             .resourceIdMatches(regex)

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/PermissionGranter.kt
@@ -10,6 +10,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
 import com.schibsted.spain.barista.interaction.BaristaSleepInteractions.sleepThread
+import com.schibsted.spain.barista.interaction.PermissionGranter.toPermissionButtonRegex
 
 object PermissionGranter {
 
@@ -27,6 +28,12 @@ object PermissionGranter {
     "com.android.packageinstaller:id/permission_allow_button"
   )
 
+  private fun List<String>.toPermissionButtonRegex() = joinToString(
+    prefix = "^(",
+    separator = "|",
+    postfix = ")$"
+  ) { it }
+
   @JvmStatic
   fun allowPermissionsIfNeeded(permissionNeeded: String) {
     try {
@@ -35,11 +42,8 @@ object PermissionGranter {
         sleepThread(PERMISSIONS_DIALOG_DELAY.toLong())
         val device = UiDevice.getInstance(getInstrumentation())
 
-        val regex = PERMISSION_DIALOG_ALLOW_FOREGROUND_IDS.joinToString(
-          prefix = "^(",
-          separator = "|",
-          postfix = ")$"
-        ) { it }
+        val regex = PERMISSION_DIALOG_ALLOW_FOREGROUND_IDS.toPermissionButtonRegex()
+
         val allowPermissions = device.findObject(UiSelector()
             .clickable(true)
             .checkable(false)
@@ -62,11 +66,8 @@ object PermissionGranter {
         sleepThread(PERMISSIONS_DIALOG_DELAY.toLong())
         val device = UiDevice.getInstance(getInstrumentation())
 
-        val regex = PERMISSION_DIALOG_ALLOW_ONE_TIME_IDS.joinToString(
-          prefix = "^(",
-          separator = "|",
-          postfix = ")$"
-        ) { it }
+        val regex = PERMISSION_DIALOG_ALLOW_ONE_TIME_IDS.toPermissionButtonRegex()
+
         val allowPermissions = device.findObject(UiSelector()
             .clickable(true)
             .checkable(false)

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.kt
@@ -22,12 +22,12 @@ class PermissionGranterTest {
     @Test
     fun grants_simple_permission() {
         launchActivity {
-            verifyPermissionNotGranted(SIMPLE_PERMISSION_1)
-            requestPermission(SIMPLE_PERMISSION_1)
+            verifyPermissionNotGranted(CONTACTS_PERMISSION)
+            requestPermission(CONTACTS_PERMISSION)
 
-            PermissionGranter.allowPermissionsIfNeeded(SIMPLE_PERMISSION_1)
+            PermissionGranter.allowPermissionsIfNeeded(CONTACTS_PERMISSION)
 
-            verifyPermissionGranted(SIMPLE_PERMISSION_1)
+            verifyPermissionGranted(CONTACTS_PERMISSION)
         }
     }
 
@@ -49,12 +49,12 @@ class PermissionGranterTest {
     @Test
     fun ignores_already_granted_permission() {
         launchActivity {
-            verifyPermissionNotGranted(SIMPLE_PERMISSION_2)
-            requestPermission(SIMPLE_PERMISSION_2)
-            PermissionGranter.allowPermissionsIfNeeded(SIMPLE_PERMISSION_2)
-            verifyPermissionGranted(SIMPLE_PERMISSION_2)
+            verifyPermissionNotGranted(CAMERA_PERMISSION)
+            requestPermission(CAMERA_PERMISSION)
+            PermissionGranter.allowPermissionOneTime(CAMERA_PERMISSION)
+            verifyPermissionGranted(CAMERA_PERMISSION)
 
-            PermissionGranter.allowPermissionsIfNeeded(SIMPLE_PERMISSION_2)
+            PermissionGranter.allowPermissionsIfNeeded(CAMERA_PERMISSION)
         }
     }
 
@@ -62,8 +62,8 @@ class PermissionGranterTest {
 }
 
 // We can't reuse permission from one test to another, because they stay granted after each test
-private const val SIMPLE_PERMISSION_1 = Manifest.permission.READ_CONTACTS
-private const val SIMPLE_PERMISSION_2 = Manifest.permission.CAMERA
+private const val CONTACTS_PERMISSION = Manifest.permission.READ_CONTACTS
+private const val CAMERA_PERMISSION = Manifest.permission.CAMERA
 private const val LOCATION_PERMISSION = Manifest.permission.ACCESS_FINE_LOCATION
 
 private fun ActivityScenario<*>.requestPermission(permission: String) {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/PermissionGranterTest.kt
@@ -22,12 +22,12 @@ class PermissionGranterTest {
     @Test
     fun grants_simple_permission() {
         launchActivity {
-            verifyPermissionNotGranted(CONTACTS_PERMISSION)
-            requestPermission(CONTACTS_PERMISSION)
+            verifyPermissionNotGranted(PERMISSION_1_CONTACTS)
+            requestPermission(PERMISSION_1_CONTACTS)
 
-            PermissionGranter.allowPermissionsIfNeeded(CONTACTS_PERMISSION)
+            PermissionGranter.allowPermissionsIfNeeded(PERMISSION_1_CONTACTS)
 
-            verifyPermissionGranted(CONTACTS_PERMISSION)
+            verifyPermissionGranted(PERMISSION_1_CONTACTS)
         }
     }
 
@@ -49,12 +49,12 @@ class PermissionGranterTest {
     @Test
     fun ignores_already_granted_permission() {
         launchActivity {
-            verifyPermissionNotGranted(CAMERA_PERMISSION)
-            requestPermission(CAMERA_PERMISSION)
-            PermissionGranter.allowPermissionOneTime(CAMERA_PERMISSION)
-            verifyPermissionGranted(CAMERA_PERMISSION)
+            verifyPermissionNotGranted(PERMISSION_2_CAMERA)
+            requestPermission(PERMISSION_2_CAMERA)
+            PermissionGranter.allowPermissionOneTime(PERMISSION_2_CAMERA)
+            verifyPermissionGranted(PERMISSION_2_CAMERA)
 
-            PermissionGranter.allowPermissionsIfNeeded(CAMERA_PERMISSION)
+            PermissionGranter.allowPermissionsIfNeeded(PERMISSION_2_CAMERA)
         }
     }
 
@@ -62,8 +62,8 @@ class PermissionGranterTest {
 }
 
 // We can't reuse permission from one test to another, because they stay granted after each test
-private const val CONTACTS_PERMISSION = Manifest.permission.READ_CONTACTS
-private const val CAMERA_PERMISSION = Manifest.permission.CAMERA
+private const val PERMISSION_1_CONTACTS = Manifest.permission.READ_CONTACTS
+private const val PERMISSION_2_CAMERA = Manifest.permission.CAMERA
 private const val LOCATION_PERMISSION = Manifest.permission.ACCESS_FINE_LOCATION
 
 private fun ActivityScenario<*>.requestPermission(permission: String) {


### PR DESCRIPTION
Updated permission granter to match ANY of the allow buttons in this order:

```kotlin
    "com.android.permissioncontroller:id/permission_allow_foreground_only_button",
    "com.android.permissioncontroller:id/permission_allow_button",
    "com.android.packageinstaller:id/permission_allow_button"
```

So we make sure that one of this buttons exists on the permission dialog.

<img width="574" alt="Captura de pantalla 2020-09-09 a las 12 31 02" src="https://user-images.githubusercontent.com/887462/92587732-539d7400-f298-11ea-9f14-ff4d3e00ee30.png">

Also, added `allowPermissionOneTime` that accepts permission just this time, so we can do tests that involves multiple permission request time

One time permissions: https://developer.android.com/guide/topics/permissions/overview#one-time