### PR TITLE
getTargetContext() #352 Replace Context Deprecated

### DIFF
--- a/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/BitmapComparatorTest.kt
+++ b/library/src/androidTest/java/com/schibsted/spain/barista/internal/util/BitmapComparatorTest.kt
@@ -1,7 +1,8 @@
 package com.schibsted.spain.barista.internal.util
 
+import android.content.Context
 import android.graphics.BitmapFactory
-import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ApplicationProvider
 import com.schibsted.spain.barista.test.R
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -11,8 +12,8 @@ class BitmapComparatorTest {
 
   @Test
   fun returnTrueWhenComparingTheSameDrawable() {
-    val aBitmap = BitmapFactory.decodeResource(InstrumentationRegistry.getTargetContext().resources, R.drawable.ic_barista)
-    val theSameBitmap = BitmapFactory.decodeResource(InstrumentationRegistry.getTargetContext().resources, R.drawable.ic_barista)
+    val aBitmap = BitmapFactory.decodeResource(ApplicationProvider.getApplicationContext<Context>().resources, R.drawable.ic_barista)
+    val theSameBitmap = BitmapFactory.decodeResource(ApplicationProvider.getApplicationContext<Context>().resources, R.drawable.ic_barista)
 
     val result = BitmapComparator.compare(aBitmap, theSameBitmap)
 
@@ -21,8 +22,8 @@ class BitmapComparatorTest {
 
   @Test
   fun returnFalseWhenComparingDifferentDrawables() {
-    val aBitmap = BitmapFactory.decodeResource(InstrumentationRegistry.getTargetContext().resources, R.drawable.ic_barista)
-    val aDifferentBitmap = BitmapFactory.decodeResource(InstrumentationRegistry.getTargetContext().resources, R.drawable.ic_launcher)
+    val aBitmap = BitmapFactory.decodeResource(ApplicationProvider.getApplicationContext<Context>().resources, R.drawable.ic_barista)
+    val aDifferentBitmap = BitmapFactory.decodeResource(ApplicationProvider.getApplicationContext<Context>().resources, R.drawable.ic_launcher)
 
     val result = BitmapComparator.compare(aBitmap, aDifferentBitmap)
 

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
@@ -1,12 +1,13 @@
 package com.schibsted.spain.barista.assertion
 
+import android.content.Context
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import com.google.android.material.textfield.TextInputLayout
-import androidx.test.InstrumentationRegistry
 import androidx.test.espresso.matcher.ViewMatchers
 import android.view.View
 import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
 import com.schibsted.spain.barista.internal.assertAny
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -16,7 +17,7 @@ object BaristaErrorAssertions {
 
   @JvmStatic
   fun assertError(@IdRes viewId: Int, @StringRes text: Int) {
-    val resourceString = InstrumentationRegistry.getTargetContext().resources.getString(text)
+    val resourceString = ApplicationProvider.getApplicationContext<Context>().resources.getString(text)
     assertError(viewId, resourceString)
   }
 

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHintAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaHintAssertions.kt
@@ -1,14 +1,15 @@
 package com.schibsted.spain.barista.assertion
 
+import android.content.Context
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
-import androidx.test.InstrumentationRegistry
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import android.view.View
 import android.widget.EditText
 import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
 import com.schibsted.spain.barista.internal.assertAny
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -18,7 +19,7 @@ object BaristaHintAssertions {
 
   @JvmStatic
   fun assertHint(@IdRes viewId: Int, @StringRes text: Int) {
-    val resourceString = InstrumentationRegistry.getTargetContext().resources.getString(text)
+    val resourceString = ApplicationProvider.getApplicationContext<Context>().resources.getString(text)
     assertHint(viewId, resourceString)
   }
 

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaListInteractions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaListInteractions.kt
@@ -1,7 +1,7 @@
 package com.schibsted.spain.barista.interaction
 
+import android.content.Context
 import androidx.annotation.IdRes
-import androidx.test.InstrumentationRegistry
 import androidx.test.espresso.AmbiguousViewMatcherException
 import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
@@ -19,6 +19,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import android.view.View
 import android.widget.AbsListView
+import androidx.test.core.app.ApplicationProvider
 import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
 import com.schibsted.spain.barista.internal.failurehandler.description
 import com.schibsted.spain.barista.internal.failurehandler.withFailureHandler
@@ -123,5 +124,5 @@ object BaristaListInteractions {
     else -> allOf(isDisplayed(), isAssignableFrom(AbsListView::class.java), withId(id))
   }
 
-  private fun resourceName(resId: Int) = InstrumentationRegistry.getTargetContext().resources.getResourceName(resId)
+  private fun resourceName(resId: Int) = ApplicationProvider.getApplicationContext<Context>().resources.getResourceName(resId)
 }

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaMenuClickInteractions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaMenuClickInteractions.kt
@@ -1,7 +1,7 @@
 package com.schibsted.spain.barista.interaction
 
+import android.content.Context
 import androidx.annotation.IdRes
-import androidx.test.InstrumentationRegistry
 import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
@@ -12,6 +12,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import android.view.View
+import androidx.test.core.app.ApplicationProvider
 import com.schibsted.spain.barista.internal.failurehandler.SpyFailureHandler
 import com.schibsted.spain.barista.internal.failurehandler.withFailureHandler
 import com.schibsted.spain.barista.internal.matcher.DisplayedMatchers.displayedAnd
@@ -74,6 +75,6 @@ object BaristaMenuClickInteractions {
   }
 
   private fun openOverflow() {
-    openActionBarOverflowOrOptionsMenu(InstrumentationRegistry.getTargetContext())
+    openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext<Context>())
   }
 }

--- a/library/src/main/java/com/schibsted/spain/barista/internal/util/ResourceType.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/util/ResourceType.kt
@@ -1,8 +1,9 @@
 package com.schibsted.spain.barista.internal.util
 
+import android.content.Context
 import android.content.res.Resources
 import android.view.View
-import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.Matcher
@@ -15,7 +16,7 @@ enum class ResourceType {
 
 val Int.resourceType: ResourceType
   get() {
-    val resourceTypeName = InstrumentationRegistry.getTargetContext().resources.getResourceTypeName(this)
+    val resourceTypeName = ApplicationProvider.getApplicationContext<Context>().resources.getResourceTypeName(this)
     return when (resourceTypeName) {
       "id" -> ResourceType.ID
       "string" -> ResourceType.STRING
@@ -35,7 +36,7 @@ enum class ColorResourceType {
 val Int.colorResourceType: ColorResourceType
   get() {
     return try {
-      when (val resourceTypeName = InstrumentationRegistry.getTargetContext().resources.getResourceTypeName(this)) {
+      when (val resourceTypeName = ApplicationProvider.getApplicationContext<Context>().resources.getResourceTypeName(this)) {
         "color" -> ColorResourceType.COLOR_RES
         "attr" -> ColorResourceType.COLOR_ATTR
         else -> throw BaristaResourceTypeException("The argument must be ColorInt or R.color.* or R.attr.*, but was $resourceTypeName")

--- a/library/src/main/java/com/schibsted/spain/barista/rule/cleardata/ClearPreferencesRule.java
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/cleardata/ClearPreferencesRule.java
@@ -3,7 +3,8 @@ package com.schibsted.spain.barista.rule.cleardata;
 import android.content.Context;
 import android.content.SharedPreferences;
 import androidx.annotation.NonNull;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,7 +39,7 @@ public class ClearPreferencesRule implements TestRule {
 
   @NonNull
   private List<SharedPreferences> getAllPreferencesFiles() {
-    Context context = InstrumentationRegistry.getTargetContext().getApplicationContext();
+    Context context = ApplicationProvider.getApplicationContext();
     String rootPath = context.getApplicationInfo().dataDir + "/shared_prefs";
     File prefsFolder = new File(rootPath);
 

--- a/library/src/main/java/com/schibsted/spain/barista/rule/cleardata/internal/FileOperations.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/cleardata/internal/FileOperations.kt
@@ -1,11 +1,12 @@
 package com.schibsted.spain.barista.rule.cleardata.internal
 
-import androidx.test.InstrumentationRegistry.getTargetContext
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import java.io.File
 
 class FileOperations {
 
-  private val appContext = getTargetContext()
+  private val appContext = ApplicationProvider.getApplicationContext<Context>()
   private val androidDirectories = arrayOf(appContext.cacheDir, appContext.filesDir)
 
   fun deleteFile(file: File) {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListViewAssertionTest.kt
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListViewAssertionTest.kt
@@ -1,6 +1,6 @@
 package com.schibsted.spain.barista.sample
 
-import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.rule.ActivityTestRule
@@ -148,7 +148,7 @@ class ListViewAssertionTest {
   }
 
   private fun openActivity(intentBuilder: ListsActivity.IntentBuilder) {
-    activityTestRule.launchActivity(intentBuilder.build(InstrumentationRegistry.getTargetContext()))
+    activityTestRule.launchActivity(intentBuilder.build(ApplicationProvider.getApplicationContext()))
   }
 
   private fun openSimpleListActivity() {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsChildClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsChildClickTest.java
@@ -1,6 +1,6 @@
 package com.schibsted.spain.barista.sample;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.PerformException;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
@@ -132,7 +132,7 @@ public class ListsChildClickTest {
   }
 
   private void openActivity(IntentBuilder intentBuilder) {
-    activity.launchActivity(intentBuilder.build(InstrumentationRegistry.getTargetContext()));
+    activity.launchActivity(intentBuilder.build(ApplicationProvider.getApplicationContext()));
   }
 
   private void assertResult(String text) {

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsClickTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsClickTest.java
@@ -1,6 +1,6 @@
 package com.schibsted.spain.barista.sample;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
@@ -228,6 +228,6 @@ public class ListsClickTest {
   }
 
   private void launchTestActivity(ListsActivity.IntentBuilder intentBuilder) {
-    activity.launchActivity(intentBuilder.build(InstrumentationRegistry.getTargetContext()));
+    activity.launchActivity(intentBuilder.build(ApplicationProvider.getApplicationContext()));
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsScrollTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/ListsScrollTest.java
@@ -1,6 +1,6 @@
 package com.schibsted.spain.barista.sample;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import com.schibsted.spain.barista.sample.util.FailureHandlerValidatorRule;
@@ -72,6 +72,6 @@ public class ListsScrollTest {
   }
 
   private void openActivity(IntentBuilder intentBuilder) {
-    activity.launchActivity(intentBuilder.build(InstrumentationRegistry.getTargetContext()));
+    activity.launchActivity(intentBuilder.build(ApplicationProvider.getApplicationContext()));
   }
 }


### PR DESCRIPTION
- Using ApplicationProvider.getApplicationContext() instead of getTargetContext()

Replacing getTargetContext() with ApplicationProvider.getApplicationContext() as stated in the deprecated info.

```
/**
   * Return a Context for the target application being instrumented. Use this to get a {@link
   * Context} representing {@link Instrumentation#getTargetContext()} into your test.
   *
   * @deprecated use {@link androidx.test.core.app.ApplicationProvider#getApplicationContext()}
   *     instead.
   */
  @Deprecated
  public static Context getTargetContext() {
    return getInstrumentation().getTargetContext();
  }
```