### PR TITLE
Add assertNoError method side of assertError methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ assertHint(R.id.edittext, "Hint");
 ```java
 assertError(R.id.edittext, R.string.error);
 assertError(R.id.edittext, "Error message");
+
+assertNoError(R.id.edittext, R.string.error);
+assertNoError(R.id.edittext, "Error message");
 ```
 
 #### Check TextInputLayout's assistive helper text

--- a/README.md
+++ b/README.md
@@ -273,11 +273,11 @@ assertHint(R.id.edittext, "Hint");
 
 #### Check TextInputLayout and EditText's errors
 ```java
-assertError(R.id.edittext, R.string.error);
-assertError(R.id.edittext, "Error message");
+assertErrorDisplayed(R.id.edittext, R.string.error);
+assertErrorDisplayed(R.id.edittext, "Error message");
 
-assertNoError(R.id.edittext, R.string.error);
-assertNoError(R.id.edittext, "Error message");
+assertNoErrorDisplayed(R.id.edittext, R.string.error);
+assertNoErrorDisplayed(R.id.edittext, "Error message");
 ```
 
 #### Check TextInputLayout's assistive helper text

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
@@ -64,7 +64,9 @@ object BaristaErrorAssertions {
       override fun matchesSafely(item: View): Boolean {
         return when (item) {
           is TextView -> item.error == null || notExpectedError != item.error.toString()
-          is TextInputLayout -> item.error == null || notExpectedError != item.error.toString()
+          is TextInputLayout -> {
+            item.error == null || notExpectedError != item.error.toString()
+          }
           else -> {
             throw UnsupportedOperationException("View of class ${item.javaClass.simpleName} not supported")
           }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
@@ -15,6 +15,30 @@ import org.hamcrest.TypeSafeMatcher
 
 object BaristaErrorAssertions {
 
+  @Deprecated(
+    message = "Use assertErrorDisplayed(id, text)",
+    replaceWith = ReplaceWith(
+      "assertErrorDisplayed(viewId, text)",
+      "com.schibsted.spain.barista.assertion.BaristaErrorAssertions.assertErrorDisplayed"
+    )
+  )
+  @JvmStatic
+  fun assertError(@IdRes viewId: Int, @StringRes text: Int) {
+    assertErrorDisplayed(viewId, text)
+  }
+
+  @Deprecated(
+    message = "Use assertErrorDisplayed(id, text)",
+    replaceWith = ReplaceWith(
+      "assertErrorDisplayed(viewId, text)",
+      "com.schibsted.spain.barista.assertion.BaristaErrorAssertions.assertErrorDisplayed"
+    )
+  )
+  @JvmStatic
+  fun assertError(@IdRes viewId: Int, text: String) {
+    assertErrorDisplayed(viewId, text)
+  }
+
   @JvmStatic
   fun assertErrorDisplayed(@IdRes viewId: Int, @StringRes text: Int) {
     val resourceString = ApplicationProvider.getApplicationContext<Context>().resources.getString(text)

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
@@ -1,13 +1,13 @@
 package com.schibsted.spain.barista.assertion
 
 import android.content.Context
-import androidx.annotation.IdRes
-import androidx.annotation.StringRes
-import com.google.android.material.textfield.TextInputLayout
-import androidx.test.espresso.matcher.ViewMatchers
 import android.view.View
 import android.widget.TextView
+import androidx.annotation.IdRes
+import androidx.annotation.StringRes
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.matcher.ViewMatchers
+import com.google.android.material.textfield.TextInputLayout
 import com.schibsted.spain.barista.internal.assertAny
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -27,14 +27,8 @@ object BaristaErrorAssertions {
   }
 
   @JvmStatic
-  fun assertNoError(@IdRes viewId: Int, @StringRes text: Int) {
-    val resourceString = ApplicationProvider.getApplicationContext<Context>().resources.getString(text)
-    assertNoError(viewId, resourceString)
-  }
-
-  @JvmStatic
-  fun assertNoError(@IdRes viewId: Int, text: String) {
-    ViewMatchers.withId(viewId).assertAny(matchNoError(text))
+  fun assertNoError(@IdRes viewId: Int) {
+    ViewMatchers.withId(viewId).assertAny(matchNoError())
   }
 
   private fun matchError(expectedError: String): Matcher<View> {
@@ -55,18 +49,16 @@ object BaristaErrorAssertions {
     }
   }
 
-  private fun matchNoError(notExpectedError: String): Matcher<View> {
+  private fun matchNoError(): Matcher<View> {
     return object : TypeSafeMatcher<View>() {
       override fun describeTo(description: Description) {
-        description.appendText("without error: ").appendText(notExpectedError)
+        description.appendText("without error")
       }
 
       override fun matchesSafely(item: View): Boolean {
         return when (item) {
-          is TextView -> item.error == null || notExpectedError != item.error.toString()
-          is TextInputLayout -> {
-            item.error == null || notExpectedError != item.error.toString()
-          }
+          is TextView -> item.error.isNullOrEmpty()
+          is TextInputLayout -> item.error.isNullOrEmpty()
           else -> {
             throw UnsupportedOperationException("View of class ${item.javaClass.simpleName} not supported")
           }

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
@@ -16,18 +16,18 @@ import org.hamcrest.TypeSafeMatcher
 object BaristaErrorAssertions {
 
   @JvmStatic
-  fun assertError(@IdRes viewId: Int, @StringRes text: Int) {
+  fun assertErrorDisplayed(@IdRes viewId: Int, @StringRes text: Int) {
     val resourceString = ApplicationProvider.getApplicationContext<Context>().resources.getString(text)
-    assertError(viewId, resourceString)
+    assertErrorDisplayed(viewId, resourceString)
   }
 
   @JvmStatic
-  fun assertError(@IdRes viewId: Int, text: String) {
+  fun assertErrorDisplayed(@IdRes viewId: Int, text: String) {
     ViewMatchers.withId(viewId).assertAny(matchError(text))
   }
 
   @JvmStatic
-  fun assertNoError(@IdRes viewId: Int) {
+  fun assertNoErrorDisplayed(@IdRes viewId: Int) {
     ViewMatchers.withId(viewId).assertAny(matchNoError())
   }
 

--- a/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/assertion/BaristaErrorAssertions.kt
@@ -26,6 +26,17 @@ object BaristaErrorAssertions {
     ViewMatchers.withId(viewId).assertAny(matchError(text))
   }
 
+  @JvmStatic
+  fun assertNoError(@IdRes viewId: Int, @StringRes text: Int) {
+    val resourceString = ApplicationProvider.getApplicationContext<Context>().resources.getString(text)
+    assertNoError(viewId, resourceString)
+  }
+
+  @JvmStatic
+  fun assertNoError(@IdRes viewId: Int, text: String) {
+    ViewMatchers.withId(viewId).assertAny(matchNoError(text))
+  }
+
   private fun matchError(expectedError: String): Matcher<View> {
     return object : TypeSafeMatcher<View>() {
       override fun describeTo(description: Description) {
@@ -36,6 +47,24 @@ object BaristaErrorAssertions {
         return when (item) {
           is TextView -> expectedError == item.error.toString()
           is TextInputLayout -> expectedError == item.error.toString()
+          else -> {
+            throw UnsupportedOperationException("View of class ${item.javaClass.simpleName} not supported")
+          }
+        }
+      }
+    }
+  }
+
+  private fun matchNoError(notExpectedError: String): Matcher<View> {
+    return object : TypeSafeMatcher<View>() {
+      override fun describeTo(description: Description) {
+        description.appendText("without error: ").appendText(notExpectedError)
+      }
+
+      override fun matchesSafely(item: View): Boolean {
+        return when (item) {
+          is TextView -> item.error == null || notExpectedError != item.error.toString()
+          is TextInputLayout -> item.error == null || notExpectedError != item.error.toString()
           else -> {
             throw UnsupportedOperationException("View of class ${item.javaClass.simpleName} not supported")
           }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
@@ -7,7 +7,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.assertion.BaristaErrorAssertions.assertError;
+import static com.schibsted.spain.barista.assertion.BaristaErrorAssertions.assertNoError;
 import static com.schibsted.spain.barista.assertion.BaristaHintAssertions.assertHint;
+import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
 
 @RunWith(AndroidJUnit4.class)
 public class HintAndErrorTest {
@@ -31,6 +33,7 @@ public class HintAndErrorTest {
 
   @Test
   public void assertErrorByString() {
+    clickOn(R.id.showErrors);
     assertError(R.id.hintanderror_inputlayout, "TextInputLayout error");
     assertError(R.id.hintanderror_inputedittext, "TextInputEditText error");
     assertError(R.id.hintanderror_edittext, "EditText error");
@@ -38,8 +41,23 @@ public class HintAndErrorTest {
 
   @Test
   public void assertErrorByResource() {
+    clickOn(R.id.showErrors);
     assertError(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
     assertError(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
     assertError(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
+  }
+
+  @Test
+  public void assertNoErrorByString() {
+    assertNoError(R.id.hintanderror_inputlayout, "TextInputLayout NoError");
+    assertNoError(R.id.hintanderror_inputedittext, "TextInputEditText NoError");
+    assertNoError(R.id.hintanderror_edittext, "EditText NoError");
+  }
+
+  @Test
+  public void assertNoErrorByResource() {
+    assertNoError(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
+    assertNoError(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
+    assertNoError(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
@@ -2,7 +2,6 @@ package com.schibsted.spain.barista.sample;
 
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
-import com.schibsted.spain.barista.assertion.BaristaErrorAssertions;
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -10,8 +9,6 @@ import org.junit.runner.RunWith;
 
 import static com.schibsted.spain.barista.assertion.BaristaErrorAssertions.assertErrorDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaErrorAssertions.assertNoErrorDisplayed;
-import static com.schibsted.spain.barista.assertion.assertErrorDisplayed;
-import static com.schibsted.spain.barista.assertion.assertNoErrorDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaHintAssertions.assertHint;
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
 

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
@@ -63,24 +63,17 @@ public class HintAndErrorTest {
   }
 
   @Test
-  public void assertNoErrorByString() {
-    assertNoError(R.id.hintanderror_inputlayout, "TextInputLayout NoError");
-    assertNoError(R.id.hintanderror_inputedittext, "TextInputEditText NoError");
-    assertNoError(R.id.hintanderror_edittext, "EditText NoError");
-  }
-
-  @Test
   public void assertNoErrorByResource() {
-    assertNoError(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
-    assertNoError(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
-    assertNoError(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
+    assertNoError(R.id.hintanderror_inputlayout);
+    assertNoError(R.id.hintanderror_inputedittext);
+    assertNoError(R.id.hintanderror_edittext);
   }
 
   @Test(expected = BaristaException.class)
   public void assertNoErrorByResourceFails() {
     clickOn(R.id.showErrors);
-    assertNoError(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
-    assertNoError(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
-    assertNoError(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
+    assertNoError(R.id.hintanderror_inputlayout);
+    assertNoError(R.id.hintanderror_inputedittext);
+    assertNoError(R.id.hintanderror_edittext);
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
@@ -2,6 +2,7 @@ package com.schibsted.spain.barista.sample;
 
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
+import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +48,20 @@ public class HintAndErrorTest {
     assertError(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
   }
 
+  @Test(expected = BaristaException.class)
+  public void assertErrorByStringFails() {
+    assertError(R.id.hintanderror_inputlayout, "TextInputLayout error");
+    assertError(R.id.hintanderror_inputedittext, "TextInputEditText error");
+    assertError(R.id.hintanderror_edittext, "EditText error");
+  }
+
+  @Test(expected = BaristaException.class)
+  public void assertErrorByResourceFails() {
+    assertError(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
+    assertError(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
+    assertError(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
+  }
+
   @Test
   public void assertNoErrorByString() {
     assertNoError(R.id.hintanderror_inputlayout, "TextInputLayout NoError");
@@ -56,6 +71,14 @@ public class HintAndErrorTest {
 
   @Test
   public void assertNoErrorByResource() {
+    assertNoError(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
+    assertNoError(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
+    assertNoError(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
+  }
+
+  @Test(expected = BaristaException.class)
+  public void assertNoErrorByResourceFails() {
+    clickOn(R.id.showErrors);
     assertNoError(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
     assertNoError(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
     assertNoError(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
@@ -2,13 +2,16 @@ package com.schibsted.spain.barista.sample;
 
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
+import com.schibsted.spain.barista.assertion.BaristaErrorAssertions;
 import com.schibsted.spain.barista.internal.failurehandler.BaristaException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.schibsted.spain.barista.assertion.BaristaErrorAssertions.assertError;
-import static com.schibsted.spain.barista.assertion.BaristaErrorAssertions.assertNoError;
+import static com.schibsted.spain.barista.assertion.BaristaErrorAssertions.assertErrorDisplayed;
+import static com.schibsted.spain.barista.assertion.BaristaErrorAssertions.assertNoErrorDisplayed;
+import static com.schibsted.spain.barista.assertion.assertErrorDisplayed;
+import static com.schibsted.spain.barista.assertion.assertNoErrorDisplayed;
 import static com.schibsted.spain.barista.assertion.BaristaHintAssertions.assertHint;
 import static com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn;
 
@@ -35,45 +38,45 @@ public class HintAndErrorTest {
   @Test
   public void assertErrorByString() {
     clickOn(R.id.showErrors);
-    assertError(R.id.hintanderror_inputlayout, "TextInputLayout error");
-    assertError(R.id.hintanderror_inputedittext, "TextInputEditText error");
-    assertError(R.id.hintanderror_edittext, "EditText error");
+    assertErrorDisplayed(R.id.hintanderror_inputlayout, "TextInputLayout error");
+    assertErrorDisplayed(R.id.hintanderror_inputedittext, "TextInputEditText error");
+    assertErrorDisplayed(R.id.hintanderror_edittext, "EditText error");
   }
 
   @Test
   public void assertErrorByResource() {
     clickOn(R.id.showErrors);
-    assertError(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
-    assertError(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
-    assertError(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
+    assertErrorDisplayed(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
+    assertErrorDisplayed(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
+    assertErrorDisplayed(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
   }
 
   @Test(expected = BaristaException.class)
   public void assertErrorByStringFails() {
-    assertError(R.id.hintanderror_inputlayout, "TextInputLayout error");
-    assertError(R.id.hintanderror_inputedittext, "TextInputEditText error");
-    assertError(R.id.hintanderror_edittext, "EditText error");
+    assertErrorDisplayed(R.id.hintanderror_inputlayout, "TextInputLayout error");
+    assertErrorDisplayed(R.id.hintanderror_inputedittext, "TextInputEditText error");
+    assertErrorDisplayed(R.id.hintanderror_edittext, "EditText error");
   }
 
   @Test(expected = BaristaException.class)
   public void assertErrorByResourceFails() {
-    assertError(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
-    assertError(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
-    assertError(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
+    assertErrorDisplayed(R.id.hintanderror_inputlayout, R.string.hintanderror_inputlayout_error);
+    assertErrorDisplayed(R.id.hintanderror_inputedittext, R.string.hintanderror_inputedittext_error);
+    assertErrorDisplayed(R.id.hintanderror_edittext, R.string.hintanderror_edittext_error);
   }
 
   @Test
   public void assertNoErrorByResource() {
-    assertNoError(R.id.hintanderror_inputlayout);
-    assertNoError(R.id.hintanderror_inputedittext);
-    assertNoError(R.id.hintanderror_edittext);
+    assertNoErrorDisplayed(R.id.hintanderror_inputlayout);
+    assertNoErrorDisplayed(R.id.hintanderror_inputedittext);
+    assertNoErrorDisplayed(R.id.hintanderror_edittext);
   }
 
   @Test(expected = BaristaException.class)
   public void assertNoErrorByResourceFails() {
     clickOn(R.id.showErrors);
-    assertNoError(R.id.hintanderror_inputlayout);
-    assertNoError(R.id.hintanderror_inputedittext);
-    assertNoError(R.id.hintanderror_edittext);
+    assertNoErrorDisplayed(R.id.hintanderror_inputlayout);
+    assertNoErrorDisplayed(R.id.hintanderror_inputedittext);
+    assertNoErrorDisplayed(R.id.hintanderror_edittext);
   }
 }

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/HintAndErrorTest.java
@@ -36,6 +36,7 @@ public class HintAndErrorTest {
   public void assertErrorByString() {
     clickOn(R.id.showErrors);
     assertErrorDisplayed(R.id.hintanderror_inputlayout, "TextInputLayout error");
+    assertErrorDisplayed(R.id.hintanderror_inputlayout, "TextInputLayout error");
     assertErrorDisplayed(R.id.hintanderror_inputedittext, "TextInputEditText error");
     assertErrorDisplayed(R.id.hintanderror_edittext, "EditText error");
   }

--- a/sample/src/main/java/com/schibsted/spain/barista/sample/HintAndErrorActivity.java
+++ b/sample/src/main/java/com/schibsted/spain/barista/sample/HintAndErrorActivity.java
@@ -1,11 +1,11 @@
 package com.schibsted.spain.barista.sample;
 
 import android.os.Bundle;
+import android.widget.EditText;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
-import androidx.appcompat.app.AppCompatActivity;
-import android.widget.EditText;
 
 public class HintAndErrorActivity extends AppCompatActivity {
   @Override
@@ -13,7 +13,7 @@ public class HintAndErrorActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_hintanderrortext);
 
-    showError();
+    findViewById(R.id.showErrors).setOnClickListener(v -> showError());
   }
 
   private void showError() {

--- a/sample/src/main/res/layout/activity_hintanderrortext.xml
+++ b/sample/src/main/res/layout/activity_hintanderrortext.xml
@@ -7,6 +7,13 @@
               android:padding="16dp"
     >
 
+  <com.google.android.material.button.MaterialButton
+      android:id="@+id/showErrors"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="Show errrors"
+      />
+
   <com.google.android.material.textfield.TextInputLayout
       android:id="@+id/hintanderror_inputlayout"
       android:layout_width="match_parent"


### PR DESCRIPTION
When playing with errors... we have a method to check for `assertError` , error is displayed...

But, we didn't had a method to check for error is not shown...