### PR TITLE
Remove travis master builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ jdk: oraclejdk8
 dist: trusty
 branches:
   only:
-  - master
   - /^v\d+\.\d+\.\d+$/
 env:
   global:


### PR DESCRIPTION
As we have a github action that builds the code, is no need to have it already on travis