### PR TITLE
Add support to vector drawable using AppCompat

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/internal/matcher/DrawableMatcher.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/internal/matcher/DrawableMatcher.kt
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.drawable.DrawableCompat
 import com.google.android.material.button.MaterialButton
 import com.schibsted.spain.barista.internal.util.BitmapComparator
@@ -77,7 +78,7 @@ class DrawableMatcher private constructor(@DrawableRes private val expectedDrawa
   }
 
   private fun View.getExpectedBitmap(): Bitmap? {
-    return resources.getDrawable(expectedDrawableRes)?.let { drawable ->
+    return AppCompatResources.getDrawable(context, expectedDrawableRes)?.let { drawable ->
       when (this) {
         is MaterialButton -> DrawableToBitmapConverter.getBitmap(setTargetDrawableTint(drawable))
         is ImageView -> DrawableToBitmapConverter.getBitmap(drawable)

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -23,6 +23,9 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
+  defaultConfig {
+    vectorDrawables.useSupportLibrary = true
+  }
 }
 
 dependencies {

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -102,7 +102,7 @@
       android:id="@+id/vector_image_view"
       android:layout_width="56dp"
       android:layout_height="56dp"
-      android:src="@drawable/barista_logo_vector"
+      app:srcCompat="@drawable/barista_logo_vector"
       />
 
   <ImageView


### PR DESCRIPTION
Hello all,

We are using Barista and recently something caught our attention: some of our tests (API 23) where failing.

Turns out it was the way drawables are handled.

This project minSDK is 19, which means (by the way of [official docs](https://developer.android.com/guide/topics/graphics/vector-drawable-resources)) that we need to use a back compat solution. Even when considering API 23, [VectorDrawableCompat](https://developer.android.com/reference/androidx/vectordrawable/graphics/drawable/VectorDrawableCompat) docs states that `For API 24 and above, this class delegates to the framework's VectorDrawable. For older API version, this class lets you create a drawable based on an XML vector graphic.` - using a compat solution would still be needed.

Let me know whatever is needed to get this in the right state.

Thank you.