### PR TITLE
Implemented repeat attempts by default

### DIFF
--- a/library/src/main/java/com/schibsted/spain/barista/rule/flaky/FlakyTestRule.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/flaky/FlakyTestRule.kt
@@ -29,6 +29,19 @@ class FlakyTestRule : TestRule {
     return this
   }
 
+  /**
+   * Utility method to use @[Repeat] by default in all test methods.
+   * <br></br>
+   * Use this method when constructing the Rule to apply a default behavior of @[Repeat] without having to add the annotation to
+   * each test. This can help you to find flaky tests.
+   * <br></br>
+   * The default behavior can be overridden with [Repeat] or [Repeat].
+   */
+  fun repeatAttemptsByDefault(defaultAttempts: Int): FlakyTestRule {
+    flakyStatementBuilder.setRepeatAttemptsByDefault(defaultAttempts)
+    return this
+  }
+
   override fun apply(base: Statement, description: Description): Statement {
     return flakyStatementBuilder
         .setBase(base)

--- a/library/src/main/java/com/schibsted/spain/barista/rule/flaky/FlakyTestRule.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/flaky/FlakyTestRule.kt
@@ -35,7 +35,7 @@ class FlakyTestRule : TestRule {
    * Use this method when constructing the Rule to apply a default behavior of @[Repeat] without having to add the annotation to
    * each test. This can help you to find flaky tests.
    * <br></br>
-   * The default behavior can be overridden with [Repeat] or [Repeat].
+   * The default behavior can be overridden with [Repeat] or [AllowFlaky].
    */
   fun repeatAttemptsByDefault(defaultAttempts: Int): FlakyTestRule {
     flakyStatementBuilder.setRepeatAttemptsByDefault(defaultAttempts)

--- a/library/src/main/java/com/schibsted/spain/barista/rule/flaky/internal/FlakyStatementBuilder.java
+++ b/library/src/main/java/com/schibsted/spain/barista/rule/flaky/internal/FlakyStatementBuilder.java
@@ -11,6 +11,8 @@ public class FlakyStatementBuilder {
   private Description description;
   private boolean useAllowFlakyByDefault = false;
   private int defaultAllowFlakyAttempts = 0;
+  private int defaultRepeatAttempts = 1;
+  private boolean useRepeatByDefault = false;
 
   public FlakyStatementBuilder setBase(Statement base) {
     this.base = base;
@@ -22,8 +24,16 @@ public class FlakyStatementBuilder {
     return this;
   }
 
+  public FlakyStatementBuilder setRepeatAttemptsByDefault(int attempts) {
+    useAllowFlakyByDefault = false;
+    useRepeatByDefault = true;
+    defaultRepeatAttempts = attempts;
+    return this;
+  }
+
   public FlakyStatementBuilder allowFlakyAttemptsByDefault(int attempts) {
     useAllowFlakyByDefault = true;
+    useRepeatByDefault = false;
     defaultAllowFlakyAttempts = attempts;
     return this;
   }
@@ -46,6 +56,8 @@ public class FlakyStatementBuilder {
       return new AllowFlakyStatement(attempts, base);
     } else if (useAllowFlakyByDefault) {
       return new AllowFlakyStatement(defaultAllowFlakyAttempts, base);
+    } else if (useRepeatByDefault) {
+      return new RepeatStatement(defaultRepeatAttempts, base);
     } else {
       return base;
     }

--- a/library/src/test/java/com/schibsted/spain/barista/rule/flaky/FlakyStatementBuilderTest.java
+++ b/library/src/test/java/com/schibsted/spain/barista/rule/flaky/FlakyStatementBuilderTest.java
@@ -45,7 +45,7 @@ public class FlakyStatementBuilderTest {
   }
 
   @Test
-  public void repeatStatementReturnedWhenRepeatSetRepeatAttemptsByDefault() throws Exception {
+  public void repeatStatementReturnedWhenSettingDefaultRepeatAttempts() throws Exception {
     Statement baseStatement = new SomeStatement();
     Description description = Description.EMPTY;
 
@@ -75,7 +75,7 @@ public class FlakyStatementBuilderTest {
   }
 
   @Test
-  public void lastStatementReturnedWhenRepeatAttemptsByDefaultAndAllowFlakyStatementUsedAtTheSameTime() throws Exception {
+  public void lastStatementReturnedWhenDefaultRepeatAttemptsAndAllowFlakyStatementUsedAtTheSameTime() throws Exception {
     Statement baseStatement = new SomeStatement();
     Description description = Description.EMPTY;
 

--- a/library/src/test/java/com/schibsted/spain/barista/rule/flaky/FlakyStatementBuilderTest.java
+++ b/library/src/test/java/com/schibsted/spain/barista/rule/flaky/FlakyStatementBuilderTest.java
@@ -45,6 +45,20 @@ public class FlakyStatementBuilderTest {
   }
 
   @Test
+  public void repeatStatementReturnedWhenRepeatSetRepeatAttemptsByDefault() throws Exception {
+    Statement baseStatement = new SomeStatement();
+    Description description = Description.EMPTY;
+
+    Statement resultStatement = new FlakyStatementBuilder()
+        .setBase(baseStatement)
+        .setDescription(description)
+        .setRepeatAttemptsByDefault(3)
+        .build();
+
+    assertTrue(resultStatement instanceof RepeatStatement);
+  }
+
+  @Test
   public void allowFlakyStatementReturnedWhenAllowFlakyAnnotationFound() throws Exception {
     Statement baseStatement = new SomeStatement();
     Description description = withAnnotations(allowFlaky());
@@ -66,6 +80,36 @@ public class FlakyStatementBuilderTest {
         .build();
 
     assertTrue(resultStatement instanceof AllowFlakyStatement);
+  }
+
+  @Test
+  public void lastStatementReturnedWhenRepeatSetRepeatAttemptsByDefaultAndAllowFlakyStatementAtTheSameTime() throws Exception {
+    Statement baseStatement = new SomeStatement();
+    Description description = Description.EMPTY;
+
+    Statement resultStatement = new FlakyStatementBuilder()
+        .setBase(baseStatement)
+        .setDescription(description)
+        .allowFlakyAttemptsByDefault(5)
+        .setRepeatAttemptsByDefault(3)
+        .build();
+
+    assertTrue(resultStatement instanceof RepeatStatement);
+  }
+
+  @Test
+  public void allowFlakyStatementReturnedWhenAllowFlakyAnnotationFoundEvenRepeatStatement() throws Exception {
+    Statement baseStatement = new SomeStatement();
+    Description description = Description.EMPTY;
+
+    Statement resultStatement = new FlakyStatementBuilder()
+        .setBase(baseStatement)
+        .setDescription(description)
+        .allowFlakyAttemptsByDefault(5)
+        .setRepeatAttemptsByDefault(3)
+        .build();
+
+    assertTrue(resultStatement instanceof RepeatStatement);
   }
 
   //region Shortcut methods

--- a/library/src/test/java/com/schibsted/spain/barista/rule/flaky/FlakyStatementBuilderTest.java
+++ b/library/src/test/java/com/schibsted/spain/barista/rule/flaky/FlakyStatementBuilderTest.java
@@ -49,11 +49,7 @@ public class FlakyStatementBuilderTest {
     Statement baseStatement = new SomeStatement();
     Description description = Description.EMPTY;
 
-    Statement resultStatement = new FlakyStatementBuilder()
-        .setBase(baseStatement)
-        .setDescription(description)
-        .setRepeatAttemptsByDefault(3)
-        .build();
+    Statement resultStatement = createStatementWithRepeatAttemptsByDefault(baseStatement, description);
 
     assertTrue(resultStatement instanceof RepeatStatement);
   }
@@ -73,43 +69,36 @@ public class FlakyStatementBuilderTest {
     Statement baseStatement = new SomeStatement();
     Description description = Description.EMPTY;
 
-    Statement resultStatement = new FlakyStatementBuilder()
-        .setBase(baseStatement)
-        .setDescription(description)
-        .allowFlakyAttemptsByDefault(5)
-        .build();
+    Statement resultStatement = createStatementWithAllowFlakyByDefault(baseStatement, description);
 
     assertTrue(resultStatement instanceof AllowFlakyStatement);
   }
 
   @Test
-  public void lastStatementReturnedWhenRepeatSetRepeatAttemptsByDefaultAndAllowFlakyStatementAtTheSameTime() throws Exception {
+  public void lastStatementReturnedWhenRepeatAttemptsByDefaultAndAllowFlakyStatementUsedAtTheSameTime() throws Exception {
     Statement baseStatement = new SomeStatement();
     Description description = Description.EMPTY;
 
-    Statement resultStatement = new FlakyStatementBuilder()
-        .setBase(baseStatement)
-        .setDescription(description)
-        .allowFlakyAttemptsByDefault(5)
-        .setRepeatAttemptsByDefault(3)
-        .build();
+    Statement resultStatement = createStatementWithFlakyAndReturn(baseStatement, description);
 
     assertTrue(resultStatement instanceof RepeatStatement);
   }
 
-  @Test
-  public void allowFlakyStatementReturnedWhenAllowFlakyAnnotationFoundEvenRepeatStatement() throws Exception {
-    Statement baseStatement = new SomeStatement();
-    Description description = Description.EMPTY;
-
-    Statement resultStatement = new FlakyStatementBuilder()
+  private Statement createStatementWithFlakyAndReturn(Statement baseStatement, Description description) {
+    return new FlakyStatementBuilder()
         .setBase(baseStatement)
         .setDescription(description)
         .allowFlakyAttemptsByDefault(5)
         .setRepeatAttemptsByDefault(3)
         .build();
+  }
 
-    assertTrue(resultStatement instanceof RepeatStatement);
+  private Statement createStatementWithAllowFlakyByDefault(Statement baseStatement, Description description) {
+    return new FlakyStatementBuilder()
+        .setBase(baseStatement)
+        .setDescription(description)
+        .allowFlakyAttemptsByDefault(5)
+        .build();
   }
 
   //region Shortcut methods
@@ -117,6 +106,14 @@ public class FlakyStatementBuilderTest {
     return new FlakyStatementBuilder()
         .setBase(baseStatement)
         .setDescription(description)
+        .build();
+  }
+
+  private Statement createStatementWithRepeatAttemptsByDefault(Statement baseStatement, Description description) {
+    return new FlakyStatementBuilder()
+        .setBase(baseStatement)
+        .setDescription(description)
+        .setRepeatAttemptsByDefault(3)
         .build();
   }
 


### PR DESCRIPTION
In this PR I've added a method that allows users to set repeat attempts by default, it works the same way than `allowFlakyAttemptsByDefault` but applies the `@Retry` annotation to all methods