### PR TITLE
Fix Issue #395: Add BaristaEditTextInteractions.typeTo()

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ openMenu();
 
 #### Writing into widgets
 ```java
-writeTo(R.id.edittext, "A great text");
+writeTo(R.id.edittext, "A great text"); // Ignores the EditText restrictions like maxLength and textFilter. It's blazing fast.
+typeTo(R.id.edittext, "A great text"); // Honors the EditText restrictions like maxLength and textFilter. It slows down the test.
 writeToAutoComplete(R.id.autocomplete, "Another great text");
 clearText(R.id.edittext)
 ```

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaEditTextInteractions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaEditTextInteractions.kt
@@ -17,7 +17,7 @@ object BaristaEditTextInteractions {
   /**
    * This uses [androidx.test.espresso.action.ViewActions.replaceText],
    * to remove any existing text and insert the characters directly,
-   * disregarding any EditText properties like `maxLength`, `textFilter`, etc.
+   * ignoring any EditText properties like `maxLength`, `textFilter`, etc.
    */
   @JvmStatic
   fun writeTo(@IdRes editTextId: Int, text: String) {

--- a/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaEditTextInteractions.kt
+++ b/library/src/main/java/com/schibsted/spain/barista/interaction/BaristaEditTextInteractions.kt
@@ -3,6 +3,7 @@ package com.schibsted.spain.barista.interaction
 import androidx.annotation.IdRes
 import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -13,6 +14,11 @@ import org.hamcrest.Matchers.anyOf
 
 object BaristaEditTextInteractions {
 
+  /**
+   * This uses [androidx.test.espresso.action.ViewActions.replaceText],
+   * to remove any existing text and insert the characters directly,
+   * disregarding any EditText properties like `maxLength`, `textFilter`, etc.
+   */
   @JvmStatic
   fun writeTo(@IdRes editTextId: Int, text: String) {
     val withId = withId(editTextId)
@@ -23,6 +29,25 @@ object BaristaEditTextInteractions {
     combinedMatcher.performAction(replaceText(text))
   }
 
+  /**
+   * This uses [androidx.test.espresso.action.ViewActions.typeText], to
+   * tap once on the EditText and type the characters like an on-screen keyboard.
+   * Most EditText properties, like `maxLength` and `textFilter` will be honored.
+   */
+  @JvmStatic
+  fun typeTo(@IdRes editTextId: Int, text: String) {
+    val withId = withId(editTextId)
+    val assignableFrom = isAssignableFrom(EditText::class.java)
+    val simpleMatcher = allOf(withId, assignableFrom)
+    val wrapperMatcher = allOf(isDescendantOfA(withId), assignableFrom)
+    val combinedMatcher = anyOf(simpleMatcher, wrapperMatcher)
+    combinedMatcher.performAction(typeText(text))
+  }
+
+  /**
+   * Clears text on the view. See also
+   * [androidx.test.espresso.action.ViewActions.clearText].
+   */
   @JvmStatic
   fun clearText(@IdRes editTextId: Int) {
     withId(editTextId).performAction(clearText())

--- a/sample/src/androidTest/java/com/schibsted/spain/barista/sample/EditTextTest.java
+++ b/sample/src/androidTest/java/com/schibsted/spain/barista/sample/EditTextTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import static com.schibsted.spain.barista.assertion.BaristaHintAssertions.assertHint;
 import static com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed;
 import static com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.clearText;
+import static com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.typeTo;
 import static com.schibsted.spain.barista.interaction.BaristaEditTextInteractions.writeTo;
 
 @RunWith(AndroidJUnit4.class)
@@ -37,6 +38,24 @@ public class EditTextTest {
   public void checkWriteOnEditText_whenParentIsNotAScrollView() {
     writeTo(R.id.edittext_centered, "Hello!");
     assertDisplayed("Hello!");
+  }
+
+  @Test
+  public void checkTypeToEditText_whenEditTextIsVisible() {
+    typeTo(R.id.edittext_constrained, "Hello1=What's-Your*Name?");
+    assertDisplayed("Hello1What");
+  }
+
+  @Test
+  public void checkTypeToEditText_whenScrollIsNeeded() {
+    typeTo(R.id.edittext_constrained_very_far_away, "Hello,ABC/123");
+    assertDisplayed("HelloABC12");
+  }
+
+  @Test
+  public void checkTypeToEditText_whenParentIsNotAScrollView() {
+    typeTo(R.id.edittext_constrained_centered, " Hello 123 ");
+    assertDisplayed("Hello123");
   }
 
   @Test

--- a/sample/src/main/res/layout/activity_edittext.xml
+++ b/sample/src/main/res/layout/activity_edittext.xml
@@ -23,11 +23,31 @@
           />
 
       <EditText
+          android:id="@+id/edittext_constrained"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:maxLength="10"
+          android:digits="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890"
+          android:inputType="textFilter"
+          android:hint="I'm a constrained EditText"
+          />
+
+      <EditText
           android:id="@+id/edittext_very_far_away"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_marginTop="800dp"
           android:hint="I'm an edittext, too!"
+          />
+
+      <EditText
+          android:id="@+id/edittext_constrained_very_far_away"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:maxLength="10"
+          android:digits="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890"
+          android:inputType="textFilter"
+          android:hint="I'm a constrained EditText"
           />
 
     </LinearLayout>
@@ -39,5 +59,17 @@
       android:layout_height="wrap_content"
       android:layout_gravity="center"
       android:hint="@string/centered_edittext"
+      />
+
+  <EditText
+      android:id="@+id/edittext_constrained_centered"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center"
+      android:layout_marginTop="50dp"
+      android:maxLength="10"
+      android:digits="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890"
+      android:inputType="textFilter"
+      android:hint="I'm a constrained EditText"
       />
 </FrameLayout>


### PR DESCRIPTION
### BaristaEditTextInteractions

* Add a new `typeTo()` Text Interaction in `BaristaEditTextInteractions`. It's similar to `writeTo()`, but it uses Espresso's `typeText()` instead of `replaceText()`.
* Add KotlinDoc/JavaDoc to the Text Interaction methods, for users to tell the difference between `writeTo()` and `typeTo()`.

--------

### activity_edittext.xml

* Add 3 new constrained `EditTexts` to the layout, for UI unit tests of `typeTo()`
* The `EditTexts` have maxLength of 10 characters, and don't allow spaces, and only allow ASCII text or digits 0-9
* More info about `EditText` filters: https://stackoverflow.com/questions/33993041/android-disable-space-only-for-edittext

--------

### EditTextTest (UI Instrumentation Tests)

* Check that `typeTo()` will constrain and limit the typed characters to ASCII and digits 0-9, as per the EditText `digits` attribute.
* Check that `typeTo()` will limit the length of the typed text to 10 characters, as per the EditText `maxLength` attribute.
* Check that `typeTo()` will disallow typing spaces into the `EditText`, if the `textFilter` does not allow it.
* Check that the auto-scroll to the `EditText` will work when `typeTo()` is called.