### PR TITLE
Remove Bintray's badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 [![Travis](https://img.shields.io/travis/rust-lang/rust.svg?label=Travis+CI)](https://travis-ci.org/github/AdevintaSpain/Barista)
 [![CI](https://github.com/AdevintaSpain/Barista/actions/workflows/main.yml/badge.svg)](https://github.com/AdevintaSpain/Barista/actions/workflows/main.yml)
-[![Download](https://api.bintray.com/packages/schibstedspain/maven/barista/images/download.svg)](https://bintray.com/schibstedspain/maven/barista/_latestVersion)
 [![Hex.pm](https://img.shields.io/hexpm/l/plug.svg)](LICENSE.md)
 
 <img src="art/barista-logo.svg" width="30%"/>


### PR DESCRIPTION
It gives a 404. So ugly. Do we have to replace it with anything? I think not, but asking is always safer 😄 