### PR TITLE
Update Gradle and AGP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,18 @@
 buildscript {
-  ext.kotlin_version = '1.3.31'
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.1'
-    classpath 'com.novoda:bintray-release:0.9.1'
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    classpath 'com.android.tools.build:gradle:4.2.1'
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
   }
 }
 
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/config/android-quality.gradle
+++ b/config/android-quality.gradle
@@ -27,32 +27,3 @@ task checkstyle(type: Checkstyle) {
 }
 
 check.dependsOn 'checkstyle', 'lint'
-
-apply plugin: 'jacoco'
-
-task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
-  group = 'reporting'
-  description = 'Generate Jacoco coverage reports after running tests.'
-  reports {
-    xml.enabled = true
-    html.enabled = true
-  }
-
-  def fileFilter = ['**/R.class',
-                    '**/R$*.class',
-                    '**/*$ViewInjector*.*',
-                    '**/BuildConfig.*',
-                    '**/Manifest*.*',
-                    '**/*Test*.*',
-                    '**/*$InjectAdapter.class',
-                    '**/*$ModuleAdapter.class',
-                    '**/*$$*',
-                    'android/**/*.*']
-  def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
-  def mainSrc = "${project.projectDir}/src/main/java"
-
-  sourceDirectories = files([mainSrc])
-  classDirectories = files([debugTree])
-  executionData = files(["${buildDir}/jacoco/testDebugUnitTest.exec",
-                         "${buildDir}/outputs/code-coverage/connected/coverage.ec"])
-}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'com.novoda.bintray-release'
 apply from: '../config/android-quality.gradle'
 
 android {
@@ -32,25 +31,8 @@ dependencies {
 
   implementation 'com.google.android.material:material:1.2.0'
 
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
   testImplementation 'junit:junit:4.12'
   testImplementation 'pl.pragmatists:JUnitParams:1.1.0'
   testImplementation 'org.assertj:assertj-core:1.7.0'
   testImplementation 'org.mockito:mockito-core:2.28.2'
-}
-
-publish {
-  userOrg = 'schibstedspain'
-  groupId = 'com.schibsted.spain'
-  artifactId = 'barista'
-  publishVersion = baristaVersion
-  desc = 'The guy who serves a great Espresso'
-  website = 'https://github.com/SchibstedSpain/Barista'
-}
-
-// Exclude Kotlin files from Javadoc due to an error generating docs from Kotlin files.
-// More info: https://github.com/novoda/bintray-release/issues/71
-tasks.withType(Javadoc) {
-  excludes = ['**/*.kt']
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -26,7 +26,6 @@ android {
 }
 
 dependencies {
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
   implementation 'androidx.legacy:legacy-support-v4:1.0.0'
   implementation 'androidx.appcompat:appcompat:1.0.2'
   implementation 'androidx.recyclerview:recyclerview:1.0.0'


### PR DESCRIPTION
- Updated Gradle 7
- Updated Kotlin 1.4
- Removed Jacoco task because of incompatibility. And we're not using it anyway.
- Removed Novoda bintray plugin. It's not compatible with newer versions of Gradle and AGP, and we can no longer publish to JCenter. We will have to reimplement the publishing for mavenCentral.