### PR TITLE
Enable Gradle build scans

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,11 @@
+plugins {
+  id "com.gradle.enterprise" version "3.4.1"
+}
+gradleEnterprise {
+  buildScan {
+    termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
+    publishAlways()
+  }
+}
 include ':sample', ':library'


### PR DESCRIPTION
[Gradle Scans](https://scans.gradle.com/#gradle) provide a lot of information about the build. This can help us find issues, check build times, task cacheability, performance issues, etc.

It's free, so... let's add them!

## Example
https://scans.gradle.com/s/ticd5otgj47ea

## Where can I find it?
The link to the Scan is published at the end of the Gradle build. In CI, you can see it in the Action logs:
![image](https://user-images.githubusercontent.com/545251/119821348-bf8d3e80-bef2-11eb-8f34-214a120f1482.png)
