### PR TITLE
Parallelise Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
         run: ./gradlew assembleDebug
 
   test:
-    needs: build
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
     timeout-minutes: 60
 


### PR DESCRIPTION
We have 2 actions, one for the build and another for running instrumentation tests.
Right now, the instrumentation action waits for the build to finish first. It takes about 2 minutes. But there's no need for that, really. There's no dependency between them or any reused output. So we could save 2 minutes by starting the instrumentation build as soon as possible.