### PR TITLE
Update Readme about the new dependency coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@ Barista makes developing UI test faster, easier and more predictable. Built on t
 
 # Download
 
+## New versions (Maven Central)
+> We are on it! Follow https://github.com/AdevintaSpain/Barista/issues/382 for updates.
+
+## Old versions (JCenter)
+> Previous versions of Barista were published on JCenter with a different dependency name. [Since JCenter doesn't allow uploading dependencies anymore](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), they won't be updated. Consider migrating to the newest version of Barista on Maven Central.
+
 Import Barista as a testing dependency:
 ```gradle
-androidTestImplementation('com.adevinta.android:barista:3.9.0') {
+androidTestImplementation('com.schibsted.spain:barista:3.9.0') {
   exclude group: 'org.jetbrains.kotlin' // Only if you already use Kotlin in your project
 }
 ```
@@ -36,9 +42,9 @@ You might need to include the Google Maven repository, required by Espresso 3:
 ```gradle
 repositories {
     google()
+    jcenter()
 }
 ```
-
 
 Barista already includes `espresso-core` and `espresso-contrib`. If you need [any other Espresso package](https://developer.android.com/topic/libraries/testing-support-library/packages.html#atsl-dependencies) you can add them yourself.
 


### PR DESCRIPTION
While preparing for the Maven Central migration [I replaced the package name and dependency coordinates](https://github.com/AdevintaSpain/Barista/pull/423) of the library. But this led to broken download instructions in the Readme! (See https://github.com/AdevintaSpain/Barista/issues/425) 

I'm adding some clarification about the different versions of Barista published in different places with different names. 
We should update the Maven Central instructions once the migration is complete. In the meantime, we should allow people to use the old dependency.

Fixes https://github.com/AdevintaSpain/Barista/issues/425