### PR TITLE
Tech: Get name for artifact from each module

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@
 ###                    LIB                    ###
 #################################################
 libVersion=4.1.0
-libArtifact=barista
 libGroup=com.adevinta.android
 
 #################################################

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 
 apply(from = "../config/android-quality.gradle")
 
+ext["PUBLISH_ARTIFACT_ID"] = "barista"
+
 apply(from = "${rootProject.projectDir}/scripts/publish-module.gradle")
 
 android {

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -29,8 +29,9 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 groupId project.property("libGroup")
-                artifactId project.property("libArtifact")
+                artifactId PUBLISH_ARTIFACT_ID
                 version project.property("libVersion")
+
                 if (project.plugins.findPlugin("com.android.library")) {
                     from components.release
                 } else {


### PR DESCRIPTION
When we updated our release process to work with sonatype, we had to add `libArtifact` to **gradle.properties**, but that not allowed us to deploy different modules to maven central.

This PR allows us to have different modules, so we can deploy #439 (barista-compose) someday!