### PR TITLE
Remove the CI badge because the test environment is flaky

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Barista
 **The one who serves a great Espresso**
 
-[![CI](https://github.com/AdevintaSpain/Barista/actions/workflows/main.yml/badge.svg)](https://github.com/AdevintaSpain/Barista/actions/workflows/main.yml)
 [![Hex.pm](https://img.shields.io/hexpm/l/plug.svg)](LICENSE.md)
 
 <img src="art/barista-logo.svg" width="30%"/>


### PR DESCRIPTION
It wasn't that reliable to test things on emulators. So now that we backed to pass the tests locally again, let's just remove the badge.