### PR TITLE
Tech: Add api 31 to test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
     strategy:
       matrix:
         api-level: [ 26, 31 ]
+      fail-fast: false
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           java-version: 11
 
       - name: Run instrumentation tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: ReactiveCircus/android-emulator-runner@v2.21.0
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
     strategy:
       matrix:
-        api-level: [ 26, 30 ]
+        api-level: [ 26, 31 ]
     timeout-minutes: 60
 
     steps:
@@ -51,7 +51,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          arch: x86
+          arch: x86_64
           profile: pixel_2
           disable-animations: true
           script: ./gradlew :sample:connectedCheck :barista-compose:connectedCheck

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,9 @@ jobs:
 
   test:
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    strategy:
+      matrix:
+        api-level: [ 26, 31 ]
     timeout-minutes: 60
 
     steps:
@@ -47,7 +50,7 @@ jobs:
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 26
+          api-level: ${{ matrix.api-level }}
           arch: x86
           profile: pixel_2
           disable-animations: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,13 @@ jobs:
 
   test:
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         api-level: [ 26, 31 ]
+        include:
+          - node: 31
+            experimental: true
       fail-fast: false
     timeout-minutes: 60
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
     strategy:
       matrix:
-        api-level: [ 26, 31 ]
+        api-level: [ 26, 30 ]
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
Update test emulators to run on APIs 26 and API 31 (Android 12), so we can start updating this library to android 12...