### PR TITLE
Fix: API 31 run tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,14 +30,9 @@ jobs:
 
   test:
     runs-on: macOS-latest # enables hardware acceleration in the virtual machine
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         api-level: [ 26, 31 ]
-        include:
-          - node: 31
-            experimental: true
-      fail-fast: false
     timeout-minutes: 60
 
     steps:

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -39,7 +39,8 @@ dependencies {
   implementation("com.google.android.material:material:1.2.0")
   implementation("androidx.core:core-ktx:1.0.1")
 
-  androidTestUtil("androidx.test:orchestrator:1.3.0")
+  androidTestUtil("androidx.test:orchestrator:1.4.1")
+
   androidTestImplementation(project(":library"))
   androidTestImplementation("org.assertj:assertj-core:2.9.1")
   androidTestImplementation("com.nhaarman:mockito-kotlin:1.5.0")


### PR DESCRIPTION
Following the dependencies page for android test i found that version 1.4.1 of orchestarator fixes the API 31 problem! YAY!

https://developer.android.com/jetpack/androidx/releases/test#orchestrator-1.4.1